### PR TITLE
Two more places where replacement is breaking.

### DIFF
--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -724,5 +724,50 @@ EOD;
 
         $this->assertEquals($expected, $result);
     }
+    
+    
+    
+    
+    /**
+     * Prefix namespaced classnames after return statement.
+     *
+     * @see https://github.com/BrianHenryIE/strauss/issues/11
+     */
+    public function testReturnedNamespacedClassIsPrefixed()
+    {
+
+        $contents = 'return \Carbon_Fields\Carbon_Fields::resolve';
+        $expected = 'return \BrianHenryIE\Strauss\Carbon_Fields\Carbon_Fields::resolve';
+
+        $config = $this->createMock(StraussConfig::class);
+
+        $replacer = new Prefixer($config, __DIR__);
+        $result = $replacer->replaceNamespace($contents, 'Carbon_Fields\Carbon_Fields', 'BrianHenryIE\Strauss\Carbon_Fields\Carbon_Fields');
+
+        $this->assertEquals($expected, $result);
+    }
+    
+    
+    /**
+     * Prefix namespaced classnames between two tabs and colon.
+     *
+     * @see https://github.com/BrianHenryIE/strauss/issues/11
+     */
+    public function testReturnedNamespacedClassIsPrefixed()
+    {
+
+        $contents = "		\Carbon_Fields\Carbon_Fields::service( 'legacy_storage' )->enable()";
+        $expected = "		\BrianHenryIE\Strauss\Carbon_Fields\Carbon_Fields::service( 'legacy_storage' )->enable()";
+
+        $config = $this->createMock(StraussConfig::class);
+
+        $replacer = new Prefixer($config, __DIR__);
+        $result = $replacer->replaceNamespace($contents, 
+                                        'Carbon_Fields\Carbon_Fields',
+                                        'BrianHenryIE\Strauss\Carbon_Fields\Carbon_Fields'
+                                        );
+
+        $this->assertEquals($expected, $result);
+    }
 
 }


### PR DESCRIPTION
I haven't gotten into that scary looking twenty-line regex `$pattern`, but in the meantime here are two tests that I believe will fail.

The lines [here](https://github.com/htmlburger/carbon-fields/blob/development/core/Loader/Loader.php#L54-L63) and [here](https://github.com/htmlburger/carbon-fields/blob/development/core/Container/Fulfillable/Fulfillable_Collection.php#L70) aren't getting recognized.