### PR TITLE
Make modified date in header optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following configuration is inferred:
 - `classmap_prefix` defines the default string to prefix class names in the global namespace
 - `packages` is the list of packages to process. If absent, all packages in the `require` key of your `composer.json` are included
 - `classmap_output` is a `bool` to decide if Strauss will create `autoload-classmap.php` and `autoload.php`. If it is not set, it is `false` if `target_directory` is in your project's `autoload` key, `true` otherwise.
+- `include_modified_date` is a `bool` to decide if Strauss should include a date in the (phpdoc) header written to modified files. Defaults to `true`.
 
 The following configuration is default:
 

--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -98,6 +98,13 @@ class StraussConfig
 
     protected array $namespaceReplacementPatterns = array();
 
+    /**
+     * Should a modified date be included in the header for modified files?
+     *
+     * @var bool
+     */
+    protected $includeModifiedDate = true;
+
 
     /**
      * Read any existing Mozart config.
@@ -451,5 +458,21 @@ class StraussConfig
     public function setNamespaceReplacementPatterns(array $namespaceReplacementPatterns): void
     {
         $this->namespaceReplacementPatterns = $namespaceReplacementPatterns;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIncludeModifiedDate(): bool
+    {
+        return $this->includeModifiedDate;
+    }
+
+    /**
+     * @param bool $includeModifiedDate
+     */
+    public function setIncludeModifiedDate(bool $includeModifiedDate): void
+    {
+        $this->includeModifiedDate = $includeModifiedDate;
     }
 }

--- a/src/Licenser.php
+++ b/src/Licenser.php
@@ -36,6 +36,8 @@ class Licenser
 
     protected string $targetDirectory;
 
+    protected bool $includeModifiedDate;
+
     /**
      * An array of files relative to the project vendor folder.
      *
@@ -61,6 +63,7 @@ class Licenser
 
         $this->targetDirectory = $config->getTargetDirectory();
         $this->vendorDir = $config->getVendorDirectory();
+        $this->includeModifiedDate = $config->isIncludeModifiedDate();
 
         $this->filesystem = new Filesystem(new Local($workingDir));
     }
@@ -157,7 +160,7 @@ class Licenser
     }
 
     /**
-     * Given a php file as a string, edit it's header phpdoc, or add a header, to include:
+     * Given a php file as a string, edit its header phpdoc, or add a header, to include:
      *
      * "Modified by {author} on {date} using Strauss.
      * @see https://github.com/BrianHenryIE/strauss"
@@ -184,7 +187,11 @@ class Licenser
         $author = $this->author;
 
         $licenseDeclaration = "@license {$packageLicense}";
-        $modifiedDeclaration = "Modified by {$author} on {$modifiedDate} using Strauss.";
+        if ($this->includeModifiedDate) {
+            $modifiedDeclaration = "Modified by {$author} on {$modifiedDate} using Strauss.";
+        } else {
+            $modifiedDeclaration = "Modified by {$author} using Strauss.";
+        }
         $straussLink = "@see https://github.com/BrianHenryIE/strauss";
 
         // php-open followed by some whitespace and new line until the first ...


### PR DESCRIPTION
We're using Strauss in a project where we include the renamespaced folder in our git repository so that people don't have to run Strauss when cloning the repository. An added benefit is that we can keep track of changes in the vendor libraries when we update them.
However, Strauss adds the license header to each file it touches:
```
 * Modified by Ewout on 06-August-2021 using Strauss.
```
And the result is that git marks all the vendor files as modified (even those that did not change).

This PR addresses this by adding an optional `include_modified_date` config parameter that allows excluding the date from the header.
```
 * Modified by Ewout using Strauss.
```