### PR TITLE
Fix: unnecessary plugins "blocked by your allow-plugins config"

### DIFF
--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -69,7 +69,7 @@ class ComposerPackage
             $absolutePath = rtrim($absolutePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'composer.json';
         }
 
-        $composer = Factory::create(new NullIO(), $absolutePath);
+        $composer = Factory::create(new NullIO(), $absolutePath, true);
 
         return new ComposerPackage($composer, $overrideAutoload);
     }

--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -83,7 +83,7 @@ class ComposerPackage
     {
         $factory = new Factory();
         $io = new NullIO();
-        $composer = $factory->createComposer($io, $jsonArray);
+	    $composer = $factory->createComposer($io, $jsonArray, true);
 
         return new ComposerPackage($composer, $overrideAutoload);
     }

--- a/src/Composer/ProjectComposerPackage.php
+++ b/src/Composer/ProjectComposerPackage.php
@@ -26,7 +26,7 @@ class ProjectComposerPackage extends ComposerPackage
         }
         unset($absolutePath);
 
-        $composer = Factory::create(new NullIO(), $absolutePathFile);
+        $composer = Factory::create(new NullIO(), $absolutePathFile, true);
 
         parent::__construct($composer, $overrideAutoload);
 


### PR DESCRIPTION
Seemed to be caused by [wptrt/admin-notices](https://github.com/WPTT/admin-notices).

No test.

```
composer/installers contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.composer/installers [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins%
```