### PR TITLE
update symfony/finder version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/composer": "*",
         "json-mapper/json-mapper": "^2.2",
         "symfony/console": "^4|^5",
-        "symfony/finder": "^4|^5",
+        "symfony/finder": "^4|^5|^6",
         "league/flysystem": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
`symfony/finder` version used by `strauss` conflicts with `illuminate/filesystem`, which has a requirement of `symfony/finder:^6`.

I've tested it and `strauss` works fine with `symfony/finder:^6`.