### PR TITLE
Handle symlinks properly

### DIFF
--- a/src/Cleanup.php
+++ b/src/Cleanup.php
@@ -115,18 +115,17 @@ class Cleanup
             );
 
             foreach ($it as $file) {
-                if ($file->isDir() && $this->dirIsEmpty($file)) {
+                if ($file->isDir() && $this->dirIsEmpty((string) $file)) {
                     rmdir((string)$file);
                 }
             }
         }
     }
 
-    // TODO: Use Symphony or Flysystem functions.
-    protected function dirIsEmpty($dir): bool
+    // TODO: Use Symfony or Flysystem functions.
+    protected function dirIsEmpty(string $dir): bool
     {
-        $absolutePath = $dir;
-        $di = new RecursiveDirectoryIterator($absolutePath, \FilesystemIterator::SKIP_DOTS);
+        $di = new RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS);
         return iterator_count($di) === 0;
     }
 

--- a/src/FileEnumerator.php
+++ b/src/FileEnumerator.php
@@ -165,7 +165,7 @@ class FileEnumerator
 
                             foreach ($finder as $foundFile) {
                                 $sourceAbsoluteFilepath = $foundFile->getPathname();
-                                $sourceRelativeFilePath = str_replace($sourcePath, $sourceRelativePath, $sourceAbsoluteFilepath);
+                                $sourceRelativeFilePath = str_replace(rtrim($sourcePath, DIRECTORY_SEPARATOR), rtrim($sourceRelativePath, DIRECTORY_SEPARATOR), $sourceAbsoluteFilepath);
                                 $outputRelativeFilepath = str_replace($prefixToRemove, '', $sourceAbsoluteFilepath);
 
                                 // For symlinked packages.

--- a/src/FileEnumerator.php
+++ b/src/FileEnumerator.php
@@ -150,7 +150,6 @@ class FileEnumerator
                                 'targetRelativeFilepath' => $outputRelativeFilepath,
                             );
                             $this->filesWithDependencies[ $outputRelativeFilepath ] = $file;
-                            continue;
                         } elseif (is_dir($sourceAbsolutePath)) {
                             // trailingslashit().
                             $namespace_relative_path = rtrim($namespace_relative_path, DIRECTORY_SEPARATOR)
@@ -166,7 +165,7 @@ class FileEnumerator
 
                             foreach ($finder as $foundFile) {
                                 $sourceAbsoluteFilepath = $foundFile->getPathname();
-                                $sourceRelativePath = str_replace($this->workingDir, '', $sourceAbsoluteFilepath);
+                                $sourceRelativeFilePath = str_replace($sourcePath, $sourceRelativePath, $sourceAbsoluteFilepath);
                                 $outputRelativeFilepath = str_replace($prefixToRemove, '', $sourceAbsoluteFilepath);
 
                                 // For symlinked packages.
@@ -192,13 +191,13 @@ class FileEnumerator
                                     continue;
                                 }
 
-                                if (!$this->filesystem->fileExists($sourceRelativePath)) {
+                                if (!$this->filesystem->fileExists($sourceRelativeFilePath)) {
                                     continue;
                                 }
 
                                 if ('<?php // This file was deleted by {@see https://github.com/BrianHenryIE/strauss}.'
                                     ===
-                                    $this->filesystem->read($sourceRelativePath)
+                                    $this->filesystem->read($sourceRelativeFilePath)
                                 ) {
                                     continue;
                                 }

--- a/tests/Integration/CleanupSymlinkIntegrationTest.php
+++ b/tests/Integration/CleanupSymlinkIntegrationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Tests\Integration;
+
+use BrianHenryIE\Strauss\Console\Commands\Compose;
+use BrianHenryIE\Strauss\Tests\Integration\Util\IntegrationTestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CleanupSymlinkIntegrationTest extends IntegrationTestCase
+{
+    /**
+     * Test case that ensures a symlinked package is not removed or cleared out by the strauss command.
+     */
+    public function testEnsureNoRemovalOfSymlinks(): void
+    {
+        $paths = [
+            $main_package_dir = $this->testsWorkingDir . '/main-package',
+            $symlinked_package_dir = $this->testsWorkingDir . '/symlinked-package',
+        ];
+
+        $this->removePaths($paths);
+
+        mkdir($main_package_dir);
+        mkdir($symlinked_package_dir . '/src/', 0777, true);
+
+        file_put_contents($main_package_dir . '/composer.json', $this->packageComposerFile());
+        file_put_contents($symlinked_package_dir . '/composer.json', $this->symlinkedComposerFile());
+        file_put_contents($symlinked_package_dir . '/src/File.php', $this->symlinkedPhpFile());
+
+        chdir($main_package_dir);
+        exec('composer install');
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $relative_symlinked_package_dir = $main_package_dir . '/vendor/strauss-test/symlinked-package';
+        try {
+            self::assertDirectoryExists($relative_symlinked_package_dir);
+            $strauss = new Compose();
+
+            $strauss->run($inputInterfaceMock, $outputInterfaceMock);
+
+            self::assertDirectoryExists($symlinked_package_dir);
+            self::assertFileExists($symlinked_package_dir . '/composer.json');
+            self::assertFileExists($symlinked_package_dir . '/src/File.php');
+
+            self::assertDirectoryDoesNotExist($relative_symlinked_package_dir);
+            self::assertFileExists(
+                $file = $main_package_dir . '/vendor_prefixed/strauss-test/symlinked-package/src/File.php'
+            );
+            self::assertStringContainsString('Prefixed\\Internal\\Package', file_get_contents($file) ?: '');
+        } finally {
+            $this->removePaths($paths);
+        }
+    }
+
+    /**
+     * Clean up after the tests.
+     * @param string[] $paths
+     */
+    private function removePaths(array $paths): void
+    {
+        foreach ($paths as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
+            exec("rm -rf " . $path);
+        }
+    }
+
+    private function packageComposerFile(): string
+    {
+        return <<<JSON
+{
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../symlinked-package",
+			"options": {
+				"symlink": true
+			}
+		}
+	],
+	"name": "strauss-test/main-package",
+	"require": {
+		"strauss-test/symlinked-package": "@dev"
+	},
+	"extra": {
+		"strauss": {
+			"target_directory": "vendor_prefixed",
+			"namespace_prefix": "Prefixed\\\\",
+			"classmap_prefix": "Prefixed_",
+			"delete_vendor_packages": true
+		}
+	}
+}
+JSON;
+    }
+
+    private function symlinkedComposerFile(): string
+    {
+        return <<<JSON
+{
+	"name": "strauss-test/symlinked-package",
+	"autoload": {
+		"psr-4": {
+			"Internal\\\\Package\\\\": "src/"
+		}
+	}
+}
+JSON;
+    }
+
+    private function symlinkedPhpFile(): string
+    {
+        return <<<PHP
+<?php
+
+namespace Internal\Package;
+
+final class File {
+}
+
+PHP;
+    }
+}


### PR DESCRIPTION
Currently the logic to resolve symlinks is flawed making Strauss ignore symlinked packages. This PR solves that problem, and adds a test to ensure the original symlink is intact after running Strauss with `"delete_vendor_packages": true`. 

Thanks for providing this tool. If this PR needs changing let me know. 

I think this PR can finish #64. 

Ref: https://github.com/BrianHenryIE/strauss/issues/64#issuecomment-1842061294