### PR TITLE
Fix invalid paths on Windows

### DIFF
--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -7,6 +7,7 @@
 
 namespace BrianHenryIE\Strauss\Composer;
 
+use BrianHenryIE\Strauss\Helpers\Path;
 use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
@@ -128,6 +129,8 @@ class ComposerPackage
         } elseif (1 === preg_match('/.*\/([^\/]*\/[^\/]*)\/composer.json/', $composerJsonFileAbsolute, $output_array)) {
             // Not every package gets installed to a folder matching its name (crewlabs/unsplash).
             $this->relativePath = $output_array[1];
+        } else {
+            $this->relativePath = Path::normalize($this->packageName);
         }
 
         if (!is_null($overrideAutoload)) {

--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -7,7 +7,6 @@
 
 namespace BrianHenryIE\Strauss\Composer;
 
-use BrianHenryIE\Strauss\Helpers\Path;
 use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
@@ -124,13 +123,11 @@ class ComposerPackage
             $this->relativePath = $this->packageName;
             $this->packageAbsolutePath = realpath($vendorDirectory . DIRECTORY_SEPARATOR . $this->packageName) . DIRECTORY_SEPARATOR;
         // If the package is symlinked, the path will be outside the working directory.
-        } elseif (0 !== strpos($absolutePath, getcwd()) && 1 === preg_match('/.*\/([^\/]*\/[^\/]*)\/[^\/]*/', $vendorDirectory, $output_array)) {
+        } elseif (0 !== strpos($absolutePath, getcwd()) && 1 === preg_match('/.*[\/\\\\]([^\/\\\\]*[\/\\\\][^\/\\\\]*)[\/\\\\][^\/\\\\]*/', $vendorDirectory, $output_array)) {
             $this->relativePath = $output_array[1];
-        } elseif (1 === preg_match('/.*\/([^\/]*\/[^\/]*)\/composer.json/', $composerJsonFileAbsolute, $output_array)) {
-            // Not every package gets installed to a folder matching its name (crewlabs/unsplash).
+        } elseif (1 === preg_match('/.*[\/\\\\]([^\/\\\\]+[\/\\\\][^\/\\\\]+)[\/\\\\]composer.json/', $composerJsonFileAbsolute, $output_array)) {
+        // Not every package gets installed to a folder matching its name (crewlabs/unsplash).
             $this->relativePath = $output_array[1];
-        } else {
-            $this->relativePath = Path::normalize($this->packageName);
         }
 
         if (!is_null($overrideAutoload)) {

--- a/src/FileEnumerator.php
+++ b/src/FileEnumerator.php
@@ -9,6 +9,7 @@ namespace BrianHenryIE\Strauss;
 
 use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use BrianHenryIE\Strauss\Helpers\Path;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use RecursiveDirectoryIterator;
@@ -125,7 +126,7 @@ class FileEnumerator
                             $this->addFile($dependency, $namespaceRelativePath, $type);
                         } elseif (is_dir($sourceAbsolutePath)) {
                             // trailingslashit(). (to remove duplicates).
-                            $sourcePath = rtrim($sourceAbsolutePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+                            $sourcePath = Path::normalize($sourceAbsolutePath);
 
 //                          $this->findFilesInDirectory()
                             $finder = new Finder();
@@ -139,7 +140,7 @@ class FileEnumerator
                                     continue;
                                 }
 
-                                $namespaceRelativePath = rtrim($namespaceRelativePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+                                $namespaceRelativePath = Path::normalize($namespaceRelativePath);
 
                                 $this->addFile(
                                     $dependency,

--- a/src/Helpers/Path.php
+++ b/src/Helpers/Path.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Helpers;
+
+class Path
+{
+    public static function normalize(string $path): string
+    {
+        return rtrim(preg_replace('#[\\\/]+#', DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/BrianHenryIE/strauss/issues/94

## The problem
Not all paths on Windows contain backslash (`\`) as a directory separator. Some paths (e.g. vendor dir returned from Composer) still contain trailing forward slash (`/`). Thats why some code such as [here](https://github.com/BrianHenryIE/strauss/blob/63f56a77cb92a53e6c2cebbab845232775dc26ec/src/FileEnumerator.php#L142) does not work.
It produces a path which ends with `/\` combo. It wouldn't be a problem in a `require` call etc, because multiple slashes get resolved correctly, so paths like `C:\path\\to/\file.php` get resolved as `C:\path\to\file.php` and it would work BUT [here](https://github.com/BrianHenryIE/strauss/blob/63f56a77cb92a53e6c2cebbab845232775dc26ec/src/FileEnumerator.php#L146) there is a `str_replace` call which aims to subtract the `$sourcePath` from `$sourceAbsoluteFilepath` to create a relative path and fails to do so due to the slash-backslash combo presence at the end of the `$sourcePath`.

## The solution
The solution is simple: just replace all occurences of one or more slash or backslash combinations with `DIRECTORY_SEPARATOR` to create a normalized path, [just like this one does](https://github.com/szaleq/strauss/blob/52a4f64979b5e5de631a0b47182671632adefe53/src/Helpers/Path.php#L9).

## Another issue about paths
IDK how it works on MacOS or Linux, but on Windows each path of [this `if-else`](https://github.com/BrianHenryIE/strauss/blob/63f56a77cb92a53e6c2cebbab845232775dc26ec/src/Composer/ComposerPackage.php#L122) condition fails, so the `$this->relativePath` is always `null` for all packages. It seems like the `$vendorDirectory` is something entirely different on different platforms... (??) For me it contains an absolute path of each package's vendor directory, e.g. `C:\project-root\vendor\brianhenrieie\strauss\vendor`... 

The solution is to just use a package name as a relative path if anything else failed. On Windows it works like a charm, I also confirmed that it didn't break anything on MacOS. I didn't delve into this much, I don't know all the possible configuration options of composer etc... but couldn't it be used as a relative package name by default? I mean, each package has a name, which has a form of `vendor-name/package-name` and it gets installed into `{project-root}/{composer-vendor-dir}/vendor-name/package-name`... Isn't it always the case?