### PR TITLE
Support Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "composer/composer": "*",
         "json-mapper/json-mapper": "^2.2",
-        "symfony/console": "^4|^5|^6",
-        "symfony/finder": "^4|^5|^6",
+        "symfony/console": "^4|^5|^6|^7",
+        "symfony/finder": "^4|^5|^6|^7",
         "league/flysystem": "^2.1|^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 11 contains Symfony v7 packages, which means we cannot install Strauss on Laravel 11 installations. This fixes it.