### PR TITLE
fix: check input options presence when updating config from CLI

### DIFF
--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -632,7 +632,7 @@ class StraussConfig
         // strauss --updateCallSites=true
         // strauss --updateCallSites=src,input,extra
 
-        if ($input->hasOption('updateCallSites')) {
+        if ($input->hasOption('updateCallSites') && $input->getOption('updateCallSites') !== null) {
             $updateCallSitesInput = $input->getOption('updateCallSites');
 
             if ('false' === $updateCallSitesInput) {
@@ -644,10 +644,10 @@ class StraussConfig
             }
         }
 
-        if ($input->hasOption('deleteVendorPackages')) {
+        if ($input->hasOption('deleteVendorPackages') && $input->getOption('deleteVendorPackages') !== null) {
             $isDeleteVendorPackagesCommandLine = $input->getOption('deleteVendorPackages') === 'true';
             $this->setDeleteVendorPackages($isDeleteVendorPackagesCommandLine);
-        } elseif ($input->hasOption('delete_vendor_packages')) {
+        } elseif ($input->hasOption('delete_vendor_packages') && $input->getOption('delete_vendor_packages') !== null) {
             $isDeleteVendorPackagesCommandLine = $input->getOption('delete_vendor_packages') === 'true';
             $this->setDeleteVendorPackages($isDeleteVendorPackagesCommandLine);
         }


### PR DESCRIPTION
This PR fixes issue with config options being overwritten when parsing CLI options.

`$input->hasOption` method returns `true` for every input option that is configured (see `Console/Commands/Compose@configure`), even when input option is not passed from CLI.

Because of that when you are not setting `deleteVendorPackages` option from CLI, the composer.json `extra` config is overwritten before doing cleanup action. All input options are optional, so to preserve `extra` config we should not change values of the config when input option values equals to `null`.