### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes       export-ignore
+/.gitignore           export-ignore
+/phpcs.xml            export-ignore
+/phpstan.neon         export-ignore
+/phpstanbootstrap.php export-ignore
+/phpunit.xml          export-ignore
+/.github              export-ignore
+/scripts              export-ignore
+/tests                export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# https://pablorsk.medium.com/be-a-git-ninja-the-gitattributes-file-e58c07c9e915
+#
+* text=auto
+
+*.php text


### PR DESCRIPTION
I noticed that on downloading the package via Composer the package loaded unnecessary files (scripts, tests, config for phpcs and phpstan). By adding .gitattributes file, we can exclude the addition of these files and folders and save people some bandwidth :D