### PR TITLE
Set up problem matcher for PHPUnit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: fileinfo
 
+      - name: Setup problem matcher for PHPUnit
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
       - name: Debugging
         run: |
           php --version
@@ -50,9 +54,6 @@ jobs:
 
       - name: Run tests with strauss.phar
         run: vendor/bin/phpunit
-
-        # TODO: get GitHub Actions annotations working again.
-#        run: vendor/bin/phpunit --printer mheap\\GithubActionsReporter\\Printer
   lint:
     runs-on: ubuntu-latest
     name: Lint project files


### PR DESCRIPTION
@BrianHenryIE It is included in setup-php action.
Catches PHPUnit errors with a regexp.

https://github.com/shivammathur/setup-php/blob/main/src/configs/pm/phpunit.json

docs: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md