### PR TITLE
Fix vendor-prefixed subdirectory permissions being copied as 0700 instead of 0755

### DIFF
--- a/src/Pipeline/Copier.php
+++ b/src/Pipeline/Copier.php
@@ -49,7 +49,9 @@ class Copier
 
         $this->absoluteTargetDir = $workingDir . $config->getTargetDirectory();
 
-        $this->filesystem = new Filesystem(new LocalFilesystemAdapter('/'));
+        $this->filesystem = new Filesystem(new LocalFilesystemAdapter('/'), [
+            'directory_visibility' => 'public',
+        ]);
     }
 
     /**
@@ -62,7 +64,6 @@ class Copier
     {
         if (! is_dir($this->absoluteTargetDir)) {
             $this->filesystem->createDirectory($this->absoluteTargetDir);
-            $this->filesystem->setVisibility($this->absoluteTargetDir, 'public');
         } else {
             foreach ($this->files->getFiles() as $file) {
                 if (!$file->isDoCopy()) {

--- a/src/Pipeline/Copier.php
+++ b/src/Pipeline/Copier.php
@@ -16,6 +16,7 @@ namespace BrianHenryIE\Strauss\Pipeline;
 use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
 use BrianHenryIE\Strauss\Files\DiscoveredFiles;
 use BrianHenryIE\Strauss\Files\File;
+use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 
@@ -50,7 +51,7 @@ class Copier
         $this->absoluteTargetDir = $workingDir . $config->getTargetDirectory();
 
         $this->filesystem = new Filesystem(new LocalFilesystemAdapter('/'), [
-            'directory_visibility' => 'public',
+            Config::OPTION_DIRECTORY_VISIBILITY => 'public',
         ]);
     }
 

--- a/tests/Issues/StraussIssue104Test.php
+++ b/tests/Issues/StraussIssue104Test.php
@@ -43,8 +43,8 @@ EOD;
 
         self::assertEquals('0755', $result);
 
-		$subfolderResult = substr(sprintf('%o', fileperms($this->testsWorkingDir . '/vendor-prefixed/psr')), -4);
+        $subfolderResult = substr(sprintf('%o', fileperms($this->testsWorkingDir . '/vendor-prefixed/psr')), -4);
 
-	    self::assertEquals('0755', $subfolderResult);
+        self::assertEquals('0755', $subfolderResult);
     }
 }

--- a/tests/Issues/StraussIssue104Test.php
+++ b/tests/Issues/StraussIssue104Test.php
@@ -42,5 +42,9 @@ EOD;
         $result = substr(sprintf('%o', fileperms($this->testsWorkingDir . '/vendor-prefixed')), -4);
 
         self::assertEquals('0755', $result);
+
+		$subfolderResult = substr(sprintf('%o', fileperms($this->testsWorkingDir . '/vendor-prefixed/psr')), -4);
+
+	    self::assertEquals('0755', $subfolderResult);
     }
 }


### PR DESCRIPTION
Right now, Strauss is creating the `vendor-prefixed/$package` directory permissions as `0700` instead of `0755` when using Flysystem 3.x (I didn't test 2.x).

This sets the entire `directory_visibility` to `public` for [Flysystem Config Options ](https://flysystem.thephpleague.com/docs/usage/filesystem-api/#config-options) for the Filesystem instance that the Copier is using.

Fixes: https://github.com/BrianHenryIE/strauss/issues/104, specifically https://github.com/BrianHenryIE/strauss/issues/104#issuecomment-2320997828