### PR TITLE
Remove duplicated silent option

### DIFF
--- a/src/Console/Commands/DependenciesCommand.php
+++ b/src/Console/Commands/DependenciesCommand.php
@@ -123,14 +123,6 @@ class DependenciesCommand extends Command
             false
         );
 
-        $this->addOption(
-            'silent',
-            's',
-            4,
-            'output level',
-            false
-        );
-
         $localFilesystemAdapter = new LocalFilesystemAdapter(
             '/',
             null,


### PR DESCRIPTION
There's already a native option named silent in Symfony 

https://github.com/symfony/console/blob/7.2/Application.php#L1134