### PR TITLE
Respect existing `composer`.`config` when creating `vendor-prefixed` autoloader

### DIFF
--- a/src/Pipeline/Autoload/DumpAutoload.php
+++ b/src/Pipeline/Autoload/DumpAutoload.php
@@ -57,10 +57,20 @@ class DumpAutoload
         $installationManager = $composer->getInstallationManager();
         $package = $composer->getPackage();
 
+        $projectComposerJson = new JsonFile($this->config->getProjectDirectory() . 'composer.json');
+        $projectComposerJsonArray = $projectComposerJson->read();
+        if (isset($projectComposerJsonArray['config'], $projectComposerJsonArray['config']['vendor-dir'])) {
+            unset($projectComposerJsonArray['config']['vendor-dir']);
+        }
+
         /**
          * Cannot use `$composer->getConfig()`, need to create a new one so the vendor-dir is correct.
          */
         $config = new \Composer\Config(false, $this->config->getProjectDirectory());
+
+        $config->merge([
+            'config' => $projectComposerJsonArray['config'] ?? []
+        ]);
 
         $generator = $composer->getAutoloadGenerator();
         $generator->setDryRun($this->config->isDryRun());

--- a/tests/Issues/StraussIssue159Test.php
+++ b/tests/Issues/StraussIssue159Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Strauss generated autoload doesn't respect `"platform-check": false`.
+ *
+ * @see https://github.com/BrianHenryIE/strauss/issues/159
+ */
+
+namespace BrianHenryIE\Strauss\Tests\Issues;
+
+use BrianHenryIE\Strauss\Tests\Integration\Util\IntegrationTestCase;
+
+/**
+ * @package BrianHenryIE\Strauss\Tests\Issues
+ * @coversNothing
+ */
+class StraussIssue159Test extends IntegrationTestCase
+{
+    public function test_autoloader_does_not_include_platform_check()
+    {
+        $composerJsonString = <<<'EOD'
+{
+  "name": "strauss/issue159",
+  "config": {
+		"platform": {
+			"php": "7.4.33"
+		},
+        "platform-check": false
+	},
+  "require": {
+    "php": ">=7.4",
+    "psr/log": "1.0.0"
+  },
+  "extra": {
+    "strauss": {
+      "namespace_prefix": "Company\\Project\\",
+      "classmap_prefix": "Company_Project_"
+	}
+  }
+}
+EOD;
+
+        chdir($this->testsWorkingDir);
+
+        file_put_contents($this->testsWorkingDir . '/composer.json', $composerJsonString);
+
+        exec('composer install --no-dev');
+
+        $exitCode = $this->runStrauss($output);
+        assert(0 === $exitCode, $output);
+
+        $this->assertFileDoesNotExist($this->testsWorkingDir . 'vendor-prefixed/composer/platform_check.php');
+    }
+}


### PR DESCRIPTION
Fix #159
