### PR TITLE
Exclude directories from license copy step

### DIFF
--- a/src/Pipeline/Licenser.php
+++ b/src/Pipeline/Licenser.php
@@ -153,7 +153,7 @@ class Licenser
                     continue;
                 }
 
-                if (!preg_match('/^.*licen.e.*/i', $filePath)) {
+                if (!preg_match('/^.*licen.e[^\\/]*$/i', $filePath)) {
                     continue;
                 }
 

--- a/src/Pipeline/Licenser.php
+++ b/src/Pipeline/Licenser.php
@@ -142,7 +142,7 @@ class Licenser
             $packagePath = $dependency->getPackageAbsolutePath();
 
             $files = $this->filesystem->listContents($packagePath, true)
-                ->filter(fn (StorageAttributes $attributes) => $attributes->isFile());;
+                ->filter(fn (StorageAttributes $attributes) => $attributes->isFile());
             foreach ($files as $file) {
                 $filePath = '/' . $file->path();
 

--- a/src/Pipeline/Licenser.php
+++ b/src/Pipeline/Licenser.php
@@ -20,6 +20,7 @@ use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
 use BrianHenryIE\Strauss\Helpers\FileSystem;
 use League\Flysystem\FilesystemException;
+use League\Flysystem\StorageAttributes;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -140,7 +141,8 @@ class Licenser
         foreach ($this->dependencies as $dependency) {
             $packagePath = $dependency->getPackageAbsolutePath();
 
-            $files = $this->filesystem->listContents($packagePath, true);
+            $files = $this->filesystem->listContents($packagePath, true)
+                ->filter(fn (StorageAttributes $attributes) => $attributes->isFile());;
             foreach ($files as $file) {
                 $filePath = '/' . $file->path();
 

--- a/tests/Unit/LicenserTest.php
+++ b/tests/Unit/LicenserTest.php
@@ -8,12 +8,13 @@ namespace BrianHenryIE\Strauss;
 use ArrayIterator;
 use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
 use BrianHenryIE\Strauss\Pipeline\Licenser;
 use BrianHenryIE\Strauss\TestCase;
+use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\DirectoryListing;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\Local\LocalFilesystemAdapter;
-use BrianHenryIE\Strauss\Helpers\FileSystem;
 use Mockery;
 
 /**
@@ -40,17 +41,26 @@ class LicenserTest extends TestCase
         $filesystemMock = Mockery::mock(FileSystem::class);
 
         $file = Mockery::mock(FileAttributes::class);
-        $file->expects('path')
-             ->andReturn(__DIR__.'/vendor/developer-name/project-name/license.md');
+        $file->expects('path')->andReturn(__DIR__.'/vendor/developer-name/project-name/license.md');
+        $file->expects('isFile')->andReturn(true);
+
+        $fileWithLicenseInPath = Mockery::mock(FileAttributes::class);
+        $fileWithLicenseInPath->expects('path')->andReturn(__DIR__.'/vendor/developer-name/license-path/other-file.md');
+        $fileWithLicenseInPath->expects('isFile')->andReturn(true);
+
+        $directory = Mockery::mock(DirectoryAttributes::class);
+        $directory->expects('isFile')->andReturn(false);
+        // directories should be skipped before accessing path
+        $directory->shouldNotReceive('path');
 
         $finderArrayIterator = new ArrayIterator(array(
-            $file
+            $file,
+            $fileWithLicenseInPath,
+            $directory,
         ));
+        $directoryListing = new DirectoryListing($finderArrayIterator);
 
-        $directoryListingMock = Mockery::mock(DirectoryListing::class);
-        $directoryListingMock->expects('getIterator')->andReturn($finderArrayIterator);
-
-        $filesystemMock->expects('listContents')->andReturn($directoryListingMock);
+        $filesystemMock->expects('listContents')->andReturn($directoryListing);
 
         $sut = new Licenser($config, $dependencies, 'BrianHenryIE', $filesystemMock);
 
@@ -58,6 +68,7 @@ class LicenserTest extends TestCase
 
         $result = $sut->getDiscoveredLicenseFiles();
 
+        self::assertCount(1, $result);
         // Currently contains an array entry: /Users/brianhenry/Sites/mozart/mozart/tests/Unit/developer-name/project-name/license.md
         self::assertStringContainsString('developer-name/project-name/license.md', $result[0]);
     }


### PR DESCRIPTION
Fixes #180

This PR restores behavior from `0.19.5` version. Some non-license files, e.g. `vendor/composer/spdx-licenses/res/spdx-licenses.json` are still considered as license because of `license` word in filename.