### PR TITLE
Check file exists, warn if not.

### DIFF
--- a/src/Pipeline/Copier.php
+++ b/src/Pipeline/Copier.php
@@ -112,12 +112,17 @@ class Copier
                     $relativeTargetPath
                 ));
                 $this->filesystem->createDirectory($targetAbsolutePath);
-            } else {
+            } elseif ($this->filesystem->fileExists($sourceAbsoluteFilepath)) {
                 $this->logger->info(sprintf(
                     'Copying file to %s',
                     $relativeTargetPath
                 ));
                 $this->filesystem->copy($sourceAbsoluteFilepath, $targetAbsolutePath);
+            } else {
+                $this->logger->warning(sprintf(
+                    'Expected file not found: %s',
+                    $relativeTargetPath
+                ));
             }
         }
     }


### PR DESCRIPTION
Initial fix.

* Could this let serious problems slip through? I.e. is it more appropriate to let an error fail here, than let a warning proceed?
* At the end of operations, before "Done" is printed, print all `warning`s again