### PR TITLE
Add option include root autoload

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Strauss potentially requires zero configuration, but likely you'll want to custo
         "packages": [
         ],
         "update_call_sites": false,
+        "include_root_autoload": false,
         "override_autoload": {
         },
         "exclude_from_copy": {
@@ -191,6 +192,7 @@ The following configuration is default:
 - `include_modified_date` is a `bool` to decide if Strauss should include a date in the (phpdoc) header written to modified files. Defaults to `true`.
 - `include_author` is a `bool` to decide if Strauss should include the author name in the (phpdoc) header written to modified files. Defaults to `true`.
 - `update_call_sites`: `false`. This can be `true`, `false` or an `array` of directories/filepaths. When set to `true` it defaults to the directories and files in the project's `autoload` key. The PHP files and directories' PHP files will be updated where they call the prefixed classes.
+- `include_root_autoload`: `false` is a boolean flag to indicate whether Strauss should include the root autoload section of your project when creating its autoloader. It is false by default. Enabling this option will allow you to require only the Strauss autoloader in your project. Note that conflicts may occur if your project enables this option, requires both the Composer and Strauss autoloaders, and uses `files` autoloading.
 
 The remainder is empty:
 
@@ -216,7 +218,9 @@ require_once __DIR__ . '/vendor-prefixed/autoload.php';
 
 If you plan to continue using Composer's autoloader you probably want to turn on `delete_vendor_packages` or set `target_directory` to `vendor`.
 
-You can use `strauss include-autoloader` to add a line to `vendor/autoload.php` which includes the autoloader for the new files. 
+You can use `strauss include-autoloader` to add a line to `vendor/autoload.php` which includes the autoloader for the new files.
+
+If you don't plan to use Composer's autoloader, you may wish to enable `include_root_autoload` so that the Strauss autoloader includes the autoload for your project.
 
 When `delete_vendor_packages` is enabled, `vendor/composer/autoload_aliases.php` is created to allow modified classes to be loaded with their old name during development. This file should not be included in your production code.
 

--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -187,6 +187,11 @@ class StraussConfig implements
     protected bool $dryRun = false;
 
     /**
+     * Should the root autoload be included when generating the strauss autoloader?
+     */
+    protected bool $includeRootAutoload = false;
+
+    /**
      * Read any existing Mozart config.
      * Overwrite it with any Strauss config.
      * Provide sensible defaults.
@@ -225,6 +230,7 @@ class StraussConfig implements
 
             $rename->addMapping(StraussConfig::class, 'exclude_prefix_packages', 'excludePackagesFromPrefixing');
 
+            $rename->addMapping(StraussConfig::class, 'include_root_autoload', 'includeRootAutoload');
 
             $rename->addMapping(StraussConfig::class, 'function_prefix', 'functionsPrefix');
 
@@ -730,6 +736,22 @@ class StraussConfig implements
     public function setDryRun(bool $dryRun): void
     {
         $this->dryRun = $dryRun;
+    }
+
+    /**
+     * Should the root autoload be included when generating the strauss autoloader?
+     */
+    public function isIncludeRootAutoload(): bool
+    {
+        return $this->includeRootAutoload;
+    }
+
+    /**
+     * @param bool $includeRootAutoload
+     */
+    public function setIncludeRootAutoload(bool $includeRootAutoload): void
+    {
+        $this->includeRootAutoload = $includeRootAutoload;
     }
 
     /**

--- a/src/Config/AutoloadConfigInterface.php
+++ b/src/Config/AutoloadConfigInterface.php
@@ -27,6 +27,8 @@ interface AutoloadConfigInterface
 
     public function isDryRun(): bool;
 
+    public function isIncludeRootAutoload(): bool;
+
     public function getNamespacePrefix(): ?string;
 
     public function getPackagesToCopy(): array;

--- a/src/Pipeline/Autoload/DumpAutoload.php
+++ b/src/Pipeline/Autoload/DumpAutoload.php
@@ -87,8 +87,8 @@ class DumpAutoload
             $projectComposerJsonArray['config']['vendor-dir'] = $relativeTargetDir;
         }
 
-        // Do not include the autoload section from the project composer.json in the vendor-prefixed autoloader.
-        if (isset($projectComposerJsonArray['autoload'])) {
+        // Include the project root autoload in the vendor-prefixed autoloader?
+        if (isset($projectComposerJsonArray['autoload']) && !$this->config->isIncludeRootAutoload()) {
             $projectComposerJsonArray['autoload'] = [];
         }
 

--- a/tests/Integration/Autoload/DumpAutoloadFeatureTest.php
+++ b/tests/Integration/Autoload/DumpAutoloadFeatureTest.php
@@ -9,11 +9,43 @@ class DumpAutoloadFeatureTest extends IntegrationTestCase
     /**
      * I think what's been happening is that the vendor-prefixed autoloader also includes the autoload directives
      * in the root composer.json. When `files` are involved, they get `require`d twice.
+     *
+     * @param string $composerJsonString Contents of the composer.json file.
+     * @param bool   $includeRootAutoload Whether the root autoload should be included in the vendor-prefixed autoloader.
+     *
+     * @dataProvider provider_fix_double_loading_of_files_autoloaders
      */
-    public function test_fix_double_loading_of_files_autoloaders(): void
+    public function test_fix_double_loading_of_files_autoloaders(string $composerJsonString, bool $includeRootAutoload): void
     {
+        mkdir($this->testsWorkingDir . 'src');
+        file_put_contents($this->testsWorkingDir . 'src/DumpAutoloadFeatureTest.php', '<?php // whatever');
 
-        $composerJsonString = <<<'EOD'
+        file_put_contents($this->testsWorkingDir . 'composer.json', $composerJsonString);
+
+        chdir($this->testsWorkingDir);
+
+        exec('composer install');
+
+        $exitCode = $this->runStrauss($output);
+        assert(0 === $exitCode, $output);
+
+        $vendorAutoloadFilesPhpString = file_get_contents($this->testsWorkingDir . 'vendor/composer/autoload_files.php');
+        $this->assertStringContainsString('DumpAutoloadFeatureTest.php', $vendorAutoloadFilesPhpString);
+
+        $vendorPrefixedAutoloadFilesPhpString = file_get_contents($this->testsWorkingDir . 'vendor-prefixed/composer/autoload_files.php');
+        if ($includeRootAutoload) {
+            $this->assertStringContainsString('DumpAutoloadFeatureTest.php', $vendorPrefixedAutoloadFilesPhpString);
+        } else {
+            $this->assertStringNotContainsString('DumpAutoloadFeatureTest.php', $vendorPrefixedAutoloadFilesPhpString);
+        }
+    }
+
+    /**
+     * Data provider for test_fix_double_loading_of_files_autoloaders.
+     */
+    public static function provider_fix_double_loading_of_files_autoloaders(): array
+    {
+        $withoutRootAutoload = <<<'EOD'
 {
     "name": "brianhenryie/dump-autoload-feature-test",
     "autoload": {
@@ -34,8 +66,56 @@ class DumpAutoloadFeatureTest extends IntegrationTestCase
 }
 EOD;
 
+        $withRootAutoload = <<<'EOD'
+{
+    "name": "brianhenryie/dump-autoload-feature-test",
+    "autoload": {
+        "files": [
+            "src/DumpAutoloadFeatureTest.php"
+        ]
+    },
+    "require": {
+        "symfony/deprecation-contracts": "*"
+    },
+    "extra": {
+        "strauss": {
+            "namespace_prefix": "BrianHenryIE\\Strauss\\",
+            "target_directory": "vendor-prefixed",
+            "delete_vendor_packages": true,
+            "include_root_autoload": true
+        }
+    }
+}
+EOD;
+
+        return [
+            'withoutRootAutoload' => [$withoutRootAutoload, false],
+            'withRootAutoload'    => [$withRootAutoload, true],
+        ];
+    }
+
+    /**
+     * Test the `include_root_autoload` option. Expect autoload classes in both the vendor and vendor-prefixed
+     * autoloader if the option is set true, otherwise only in the vendor autoloader.
+     *
+     * @param string $composerJsonString    Contents of the composer.json file.
+     * @param bool   $expectAutoloadClasses Whether autoload classes are expected in the vendor-prefixed autoloader.
+     *
+     * @dataProvider provider_option_include_root_autoload
+     */
+    public function test_option_include_root_autoload(string $composerJsonString, bool $expectRootAutoload): void
+    {
         mkdir($this->testsWorkingDir . 'src');
-        file_put_contents($this->testsWorkingDir . 'src/DumpAutoloadFeatureTest.php', '<?php // whatever');
+
+        $classContent = <<<'EOD'
+<?php
+
+namespace BrianHenryIE\Strauss;
+
+class DumpAutoloadFeatureTest {}
+EOD;
+
+        file_put_contents($this->testsWorkingDir . 'src/DumpAutoloadFeatureTest.php', $classContent);
 
         file_put_contents($this->testsWorkingDir . 'composer.json', $composerJsonString);
 
@@ -44,12 +124,95 @@ EOD;
         exec('composer install');
 
         $exitCode = $this->runStrauss($output);
-        $this->assertEquals(0, $exitCode, $output);
+        assert(0 === $exitCode, $output);
 
-        $vendorAutoloadFilesPhpString = file_get_contents($this->testsWorkingDir . 'vendor/composer/autoload_files.php');
-        $this->assertStringContainsString('DumpAutoloadFeatureTest.php', $vendorAutoloadFilesPhpString);
+        $targetString = '\'BrianHenryIE\\\\Strauss\\\\\' => array($baseDir . \'/src\'),';
+        $vendorAutoloadPsr4PhpString = file_get_contents($this->testsWorkingDir . 'vendor/composer/autoload_psr4.php');
+        $vendorPrefixedAutoloadPsr4PhpString = file_get_contents($this->testsWorkingDir . 'vendor-prefixed/composer/autoload_psr4.php');
 
-        $vendorPrefixedAutoloadFilesPhpString = file_get_contents($this->testsWorkingDir . 'vendor-prefixed/composer/autoload_files.php');
-        $this->assertStringNotContainsString('DumpAutoloadFeatureTest.php', $vendorPrefixedAutoloadFilesPhpString);
+        if ($expectRootAutoload) {
+            $this->assertStringContainsString($targetString, $vendorAutoloadPsr4PhpString);
+            $this->assertStringContainsString($targetString, $vendorPrefixedAutoloadPsr4PhpString);
+        } else {
+            $this->assertStringContainsString($targetString, $vendorAutoloadPsr4PhpString);
+            $this->assertStringNotContainsString($targetString, $vendorPrefixedAutoloadPsr4PhpString);
+        }
+    }
+
+    /**
+     * Data provider for test_option_include_root_autoload.
+     */
+    public static function provider_option_include_root_autoload(): array
+    {
+        $rootAutoloadNotSet = <<<'EOD'
+{
+    "name": "brianhenryie/dump-autoload-feature-test",
+    "autoload": {
+        "psr-4": {
+            "BrianHenryIE\\Strauss\\": "src/"
+        }
+    },
+    "require": {
+        "symfony/deprecation-contracts": "*"
+    },
+    "extra": {
+        "strauss": {
+            "namespace_prefix": "BrianHenryIE\\Strauss\\",
+            "target_directory": "vendor-prefixed",
+            "delete_vendor_packages": true
+        }
+    }
+}
+EOD;
+
+        $rootAutoloadSetTrue = <<<'EOD'
+{
+    "name": "brianhenryie/dump-autoload-feature-test",
+    "autoload": {
+        "psr-4": {
+            "BrianHenryIE\\Strauss\\": "src/"
+        }
+    },
+    "require": {
+        "symfony/deprecation-contracts": "*"
+    },
+    "extra": {
+        "strauss": {
+            "namespace_prefix": "BrianHenryIE\\Strauss\\",
+            "target_directory": "vendor-prefixed",
+            "delete_vendor_packages": true,
+            "include_root_autoload": true
+        }
+    }
+}
+EOD;
+
+        $rootAutoloadSetFalse = <<<'EOD'
+{
+    "name": "brianhenryie/dump-autoload-feature-test",
+    "autoload": {
+        "psr-4": {
+            "BrianHenryIE\\Strauss\\": "src/"
+        }
+    },
+    "require": {
+        "symfony/deprecation-contracts": "*"
+    },
+    "extra": {
+        "strauss": {
+            "namespace_prefix": "BrianHenryIE\\Strauss\\",
+            "target_directory": "vendor-prefixed",
+            "delete_vendor_packages": true,
+            "include_root_autoload": false
+        }
+    }
+}
+EOD;
+
+        return [
+            'rootAutoloadNotSet'   => [$rootAutoloadNotSet, false],
+            'rootAutoloadSetTrue'  => [$rootAutoloadSetTrue, true],
+            'rootAutoloadSetFalse' => [$rootAutoloadSetFalse, false],
+        ];
     }
 }


### PR DESCRIPTION
feat: add option to include root autoload in vendor-prefixed autoloader
 
add extra > strauss > include_root_autoload boolean option which enables strauss to include the project root autoload when building the vendor-prefixed autoloader.

closes BrianHenryIE/strauss#214