### PR TITLE
Resolve an issue with ABSPATH in plugins.

### DIFF
--- a/bin/strauss
+++ b/bin/strauss
@@ -1,6 +1,11 @@
 #!/usr/bin/env php
 <?php
 call_user_func(function ($version) {
+    // Define ABSPATH to prevent WordPress plugin files from exiting when autoloaded
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', getcwd() . '/');
+    }
+    
     $autoloaders = Phar::running() === ''
         ? [
             __DIR__ . '/../../autoload.php',     // Relative path from vendor/brianhenryie/strauss/bin/strauss to vendor/autoload.php.


### PR DESCRIPTION
A common security practice for WordPress plugins is to include a check for ABSPATH at the top of files and exit early if it does not exist.

Here is the most common pattern:

```
if ( ! defined( 'ABSPATH' ) ) {
	exit; // Exit if accessed directly
}
```

That guard was causing strauss to exit before processing anything. This patch adds that constant back so the plugin code can be loaded without stopping strauss execution.