### PR TITLE
Add support for excluding constants from prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ Strauss potentially requires zero configuration, but likely you'll want to custo
             "file_patterns": [
             ]
         },
+        "exclude_constants": {
+            "packages": [
+            ],
+            "namespaces": [
+            ],
+            "file_patterns": [
+            ],
+            "constants": [
+            ]
+        },
         "namespace_replacement_patterns" : {
         },
         "delete_vendor_packages": false,
@@ -206,6 +216,11 @@ The remainder is empty:
 - `exclude_from_prefix`
   - [`packages`](https://github.com/BrianHenryIE/strauss/blob/83484b79cfaa399bba55af0bf4569c24d6eb169d/src/ChangeEnumerator.php#L86-L90) array of package names to exclude from prefixing.
   - [`namespaces`](https://github.com/BrianHenryIE/strauss/blob/83484b79cfaa399bba55af0bf4569c24d6eb169d/src/ChangeEnumerator.php#L177-L181) array of exact match namespaces to exclude (i.e. not substring/parent namespaces)
+- `exclude_constants` – same shape as `exclude_from_prefix`, but applies only to constants (e.g. from `define()` or `const`). Use to avoid prefixing runtime constants like `WP_PLUGIN_DIR`, `ABSPATH`.
+  - `packages` array of package names whose constants are not prefixed
+  - `namespaces` array of namespaces (prefix match) whose constants are not prefixed
+  - `file_patterns` array of regex patterns for file paths
+  - `constants` array of constant names to never prefix (e.g. `["WP_PLUGIN_DIR", "ABSPATH"]`)
 - [`namespace_replacement_patterns`](https://github.com/BrianHenryIE/strauss/blob/83484b79cfaa399bba55af0bf4569c24d6eb169d/src/ChangeEnumerator.php#L183-L190) a dictionary to use in `preg_replace` instead of prefixing with `namespace_prefix`.
 
 ## Autoloading

--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -138,6 +138,13 @@ class StraussConfig implements
     protected array $excludeFromPrefix = array('file_patterns'=>array(),'namespaces'=>array(),'packages'=>array());
 
     /**
+     * Exclude constants from prefixing only (same shape as exclude_from_prefix).
+     *
+     * @var array{packages: string[], namespaces: string[], file_patterns: string[], constants: string[]}
+     */
+    protected array $excludeConstants = array('file_patterns'=>array(),'namespaces'=>array(),'packages'=>array(),'constants'=>array());
+
+    /**
      * An array of autoload keys to replace packages' existing autoload key.
      *
      * e.g. when
@@ -567,6 +574,59 @@ class StraussConfig implements
         return $this->excludeFromPrefix['file_patterns'] ?? array();
     }
 
+    /**
+     * @param array{packages?:array<string>, namespaces?:array<string>, file_patterns?:array<string>, constants?:array<string>} $excludeConstants
+     */
+    public function setExcludeConstants(array $excludeConstants): void
+    {
+        if (isset($excludeConstants['packages'])) {
+            $this->excludeConstants['packages'] = $excludeConstants['packages'];
+        }
+        if (isset($excludeConstants['namespaces'])) {
+            $this->excludeConstants['namespaces'] = $excludeConstants['namespaces'];
+        }
+        if (isset($excludeConstants['file_patterns'])) {
+            $this->excludeConstants['file_patterns'] = $excludeConstants['file_patterns'];
+        }
+        if (isset($excludeConstants['constants'])) {
+            $this->excludeConstants['constants'] = $excludeConstants['constants'];
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludePackagesFromConstantPrefixing(): array
+    {
+        return $this->excludeConstants['packages'] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludeNamespacesFromConstantPrefixing(): array
+    {
+        return array_map(
+            fn(string $ns) => trim($ns, '\\/'),
+            $this->excludeConstants['namespaces'] ?? []
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludeFilePatternsFromConstantPrefixing(): array
+    {
+        return $this->excludeConstants['file_patterns'] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludeConstantNames(): array
+    {
+        return $this->excludeConstants['constants'] ?? [];
+    }
 
     /**
      * @return array{}|array<string, array{files?:array<string>,classmap?:array<string>,"psr-4":array<string|array<string>>}> $overrideAutoload Dictionary of package name: autoload rules.

--- a/src/Config/MarkSymbolsForRenamingConfigInterface.php
+++ b/src/Config/MarkSymbolsForRenamingConfigInterface.php
@@ -37,4 +37,28 @@ interface MarkSymbolsForRenamingConfigInterface
      * @return string[]
      */
     public function getExcludeNamespacesFromCopy(): array;
+
+    /**
+     * Config: extra.strauss.exclude_constants – applied only to constants.
+     *
+     * @return string[]
+     */
+    public function getExcludePackagesFromConstantPrefixing(): array;
+
+    /**
+     * @return string[]
+     */
+    public function getExcludeNamespacesFromConstantPrefixing(): array;
+
+    /**
+     * @return string[]
+     */
+    public function getExcludeFilePatternsFromConstantPrefixing(): array;
+
+    /**
+     * Explicit constant names to never prefix (e.g. WP_PLUGIN_DIR, ABSPATH).
+     *
+     * @return string[]
+     */
+    public function getExcludeConstantNames(): array;
 }


### PR DESCRIPTION
Introduced a new configuration option `exclude_constants` to allow users to specify constants that should not be prefixed. This includes arrays for packages, namespaces, file patterns, and specific constant names. Updated relevant classes and interfaces to handle this new feature, ensuring constants like `WP_PLUGIN_DIR` and `ABSPATH` can be excluded from renaming.

Example `composer.json`:

```json
{
    "name": "webfx/webfx-wordpress-plugin-pokemon",
    "description": "WebFX WordPress Plugin Pokemon",
    "type": "wordpress-plugin",
    "license": "GPL-2.0-or-later",
    "scripts": {
        "post-install-cmd": [
            "@strauss-prefix-namespaces"
        ],
        "post-update-cmd": [
            "@strauss-prefix-namespaces"
        ],
        "post-autoload-dump": [
            "@strauss-include-autoloader"
        ],
        "strauss-install": [
            "(test -f strauss.phar && php strauss.phar --version && [ \"$(php strauss.phar --version)\" = \"strauss 0.26.5-andrewjdawes.3\" ]) || (rm -f strauss.phar && curl -o strauss.phar -L -C - https://github.com/AndrewJDawes/strauss/releases/download/0.26.5-andrewjdawes.3/strauss.phar && php strauss.phar --version)"
        ],
        "strauss": [
            "@php strauss.phar"
        ],
        "strauss-prefix-namespaces": [
            "@strauss-install",
            "@strauss",
            "@composer dump-autoload"
        ],
        "strauss-include-autoloader": [
            "@strauss-install",
            "@strauss include-autoloader"
        ],
        "test": "phpunit",
        "analyze": "php -d memory_limit=512M vendor/bin/phpstan",
        "sniff": "phpcs -ps src/ includes/ tests/",
        "fix": "phpcbf src/ includes/ tests/",
        "cover-php": ["@putenv XDEBUG_MODE=coverage", "phpunit --coverage-cobertura coverage-report/cobertura.xml"],
        "cover-php-html": ["@putenv XDEBUG_MODE=coverage", "phpunit --coverage-cobertura coverage-report/cobertura.xml --coverage-html coverage-report"],
        "debug": [
            "@putenv XDEBUG_SESSION=1",
            "@composer run --"
        ]
    },
    "minimum-stability": "stable",
    "prefer-stable": true,
    "require": {
        "scrivo/highlight.php": "^9.18",
        "monolog/monolog": "^3.9",
        "htmlburger/carbon-fields": "^3.6",
        "codekaizen/wp-package-auto-updater": "^2.0"
    },
    "require-dev": {
        "phpstan/phpstan": "^2.1",
        "phpunit/phpunit": "^9.6",
        "squizlabs/php_codesniffer": "^3.0",
        "wp-coding-standards/wpcs": "^3.0",
        "mockery/mockery": "^1.6",
        "phpstan/phpstan-mockery": "^2.0",
        "szepeviktor/phpstan-wordpress": "^2.0",
        "10up/wp_mock": "^1.1"
    },
    "autoload": {
        "psr-4": {
            "WebFX\\WebFXWordPressPluginPokemon\\": "includes/"
        }
    },
    "config": {
        "allow-plugins": {
            "dealerdirect/phpcodesniffer-composer-installer": true
        }
    },
    "extra": {
        "strauss": {
            "target_directory": "vendor",
            "namespace_prefix": "WebFX\\WebFXWordPressPluginPokemon\\Dependencies\\",
            "classmap_prefix": "WebFX_WebFXWordPressPluginPokemon_Dependencies_",
            "constant_prefix": "WEBFX_WORDPRESS_PLUGIN_POKEMON_DEPENDENCIES_",
            "update_call_sites": true,
            "override_autoload": {
                "htmlburger/carbon-fields": {
                    "classmap": [
                        "."
                    ],
                    "files": [
                        "config.php"
                    ]
                }
            },
            "exclude_constants": {
                "constants": [
                    "ABSPATH",
                    "ADMIN_COOKIE_PATH",
                    "ALLOW_SUBDIRECTORY_INSTALL",
                    "ALLOW_UNFILTERED_UPLOADS",
                    "APP_REQUEST",
                    "AUTH_COOKIE",
                    "AUTH_KEY",
                    "AUTH_SALT",
                    "AUTOMATIC_UPDATER_DISABLED",
                    "AUTOSAVE_INTERVAL",
                    "BACKGROUND_IMAGE",
                    "BLOG_ID_CURRENT_SITE",
                    "BLOGUPLOADDIR",
                    "COMMENTS_TEMPLATE",
                    "COMPRESS_CSS",
                    "COMPRESS_SCRIPTS",
                    "CONCATENATE_SCRIPTS",
                    "COOKIE_DOMAIN",
                    "COOKIEHASH",
                    "COOKIEPATH",
                    "CORE_UPGRADE_SKIP_NEW_BUNDLED",
                    "CUSTOM_TAGS",
                    "CUSTOM_USER_META_TABLE",
                    "CUSTOM_USER_TABLE",
                    "DB_CHARSET",
                    "DB_COLLATE",
                    "DB_HOST",
                    "DB_NAME",
                    "DB_PASSWORD",
                    "DB_USER",
                    "DAY_IN_SECONDS",
                    "DIEONDBERROR",
                    "DISALLOW_FILE_EDIT",
                    "DISALLOW_FILE_MODS",
                    "DISALLOW_UNFILTERED_HTML",
                    "DISABLE_WP_CRON",
                    "DOING_AJAX",
                    "DOING_AUTOSAVE",
                    "DOING_CRON",
                    "DOMAIN_CURRENT_SITE",
                    "EMPTY_TRASH_DAYS",
                    "ENFORCE_GZIP",
                    "ERRORLOGFILE",
                    "FS_CHMOD_DIR",
                    "FS_CHMOD_FILE",
                    "FS_CONNECT_TIMEOUT",
                    "FS_METHOD",
                    "FS_TIMEOUT",
                    "FTP_BASE",
                    "FTP_CONTENT_DIR",
                    "FTP_HOST",
                    "FTP_LANG_DIR",
                    "FTP_PASS",
                    "FTP_PLUGIN_DIR",
                    "FTP_PRIKEY",
                    "FTP_PUBKEY",
                    "FTP_SSH",
                    "FTP_SSL",
                    "FTP_USER",
                    "FORCE_SSL_ADMIN",
                    "FORCE_SSL_LOGIN",
                    "HEADER_IMAGE",
                    "HEADER_IMAGE_HEIGHT",
                    "HEADER_IMAGE_WIDTH",
                    "HEADER_TEXTCOLOR",
                    "HOUR_IN_SECONDS",
                    "IFRAME_REQUEST",
                    "IMAGE_EDIT_OVERWRITE",
                    "IS_PROFILE_PAGE",
                    "LOGGED_IN_COOKIE",
                    "LOGGED_IN_KEY",
                    "LOGGED_IN_SALT",
                    "MEDIA_TRASH",
                    "MINUTE_IN_SECONDS",
                    "MULTISITE",
                    "NO_HEADER_TEXT",
                    "NOBLOGREDIRECT",
                    "NONCE_KEY",
                    "NONCE_SALT",
                    "PASS_COOKIE",
                    "PATH_CURRENT_SITE",
                    "PLUGINS_COOKIE_PATH",
                    "REST_REQUEST",
                    "SAVEQUERIES",
                    "SCRIPT_DEBUG",
                    "SECURE_AUTH_COOKIE",
                    "SECURE_AUTH_KEY",
                    "SECURE_AUTH_SALT",
                    "SHORTINIT",
                    "SITE_ID_CURRENT_SITE",
                    "SITECOOKIEPATH",
                    "STYLESHEETPATH",
                    "SUBDOMAIN_INSTALL",
                    "SUNRISE",
                    "TEMPLATEPATH",
                    "TEST_COOKIE",
                    "UPLOADBLOGSDIR",
                    "UPLOADS",
                    "USER_COOKIE",
                    "WEEK_IN_SECONDS",
                    "WPLANG",
                    "WP_ACCESSIBLE_HOSTS",
                    "WP_ADMIN",
                    "WP_ALLOW_MULTISITE",
                    "WP_ALLOW_REPAIR",
                    "WP_AUTO_UPDATE_CORE",
                    "WP_BLOG_ADMIN",
                    "WP_CACHE",
                    "WP_CONTENT_DIR",
                    "WP_CONTENT_URL",
                    "WP_CRON_LOCK_TIMEOUT",
                    "WP_DEBUG",
                    "WP_DEBUG_DISPLAY",
                    "WP_DEBUG_LOG",
                    "WP_DEFAULT_THEME",
                    "WP_ENVIRONMENT_TYPE",
                    "WP_ENVIRONMENT_TYPES",
                    "WP_HOME",
                    "WP_HTTP_BLOCK_EXTERNAL",
                    "WP_IMPORTING",
                    "WP_INSTALLING",
                    "WP_INSTALLING_NETWORK",
                    "WP_LANG_DIR",
                    "WP_LOAD_IMPORTERS",
                    "WP_LOCAL_DEV",
                    "WP_MAIL_INTERVAL",
                    "WP_MAX_MEMORY_LIMIT",
                    "WP_MEMORY_LIMIT",
                    "WP_NETWORK_ADMIN",
                    "WP_PLUGIN_DIR",
                    "WP_PLUGIN_URL",
                    "WP_POST_REVISIONS",
                    "WP_PROXY_BYPASS_HOSTS",
                    "WP_PROXY_HOST",
                    "WP_PROXY_PASSWORD",
                    "WP_PROXY_PORT",
                    "WP_PROXY_USERNAME",
                    "WP_REPAIRING",
                    "WP_SANDBOX_SCRAPING",
                    "WP_SETUP_CONFIG",
                    "WP_SITEURL",
                    "WP_START_TIMESTAMP",
                    "WP_TEMP_DIR",
                    "WP_TESTS_CONFIG_FILE_PATH",
                    "WP_UNINSTALL_PLUGIN",
                    "WP_USE_THEMES",
                    "WP_USER_ADMIN",
                    "WPINC",
                    "WPMU_ACCEL_REDIRECT",
                    "WPMU_PLUGIN_DIR",
                    "WPMU_PLUGIN_URL",
                    "WPMU_SENDFILE",
                    "XMLRPC_REQUEST",
                    "YEAR_IN_SECONDS"
                ]
            }
        }
    }
}
```