### PR TITLE
Fix fatal error when scanning template files with placeholder tokens

### DIFF
--- a/src/Pipeline/FileSymbolScanner.php
+++ b/src/Pipeline/FileSymbolScanner.php
@@ -190,7 +190,11 @@ class FileSymbolScanner
 
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
-        $ast = $parser->parse(trim($contents)) ?? [];
+        try {
+            $ast = $parser->parse(trim($contents)) ?? [];
+        } catch (\PhpParser\Error $e) {
+            return [];
+        }
 
         foreach ($ast as $rootNode) {
             if ($rootNode instanceof Node\Stmt\Namespace_) {

--- a/src/Pipeline/Prefixer.php
+++ b/src/Pipeline/Prefixer.php
@@ -205,7 +205,11 @@ class Prefixer
     protected function replaceConstFetchNamespaces(DiscoveredSymbols $symbols, string $contents): string
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
-        $ast = $parser->parse($contents);
+        try {
+            $ast = $parser->parse($contents);
+        } catch (\PhpParser\Error $e) {
+            return $contents;
+        }
 
         $namespaceSymbols = $symbols->getDiscoveredNamespaces($this->config->getNamespacePrefix());
         if (empty($namespaceSymbols)) {
@@ -505,7 +509,11 @@ class Prefixer
 
         $nodeFinder = new NodeFinder();
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
-        $ast = $parser->parse($contents);
+        try {
+            $ast = $parser->parse($contents);
+        } catch (\PhpParser\Error $e) {
+            return $contents;
+        }
 
         $positions = [];
 
@@ -598,7 +606,11 @@ class Prefixer
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
-        $ast = $parser->parse($phpFileContent);
+        try {
+            $ast = $parser->parse($phpFileContent);
+        } catch (\PhpParser\Error $e) {
+            return $phpFileContent;
+        }
 
         $traverser = new NodeTraverser();
         $visitor = new class($discoveredNamespaceSymbols) extends \PhpParser\NodeVisitorAbstract {

--- a/tests/Unit/Pipeline/FileSymbolScannerTest.php
+++ b/tests/Unit/Pipeline/FileSymbolScannerTest.php
@@ -1090,4 +1090,48 @@ EOD;
 
         self::assertArrayHasKey('twig_cycle', $result->getDiscoveredFunctions());
     }
+
+    /**
+     * Template files with placeholder tokens (e.g. `%g_namespace%`) are not valid PHP.
+     * Strauss should skip them gracefully rather than throwing a fatal error.
+     *
+     * @covers ::findInFiles
+     */
+    public function testTemplateFileWithPlaceholdersIsSkippedGracefully(): void
+    {
+        $contents = <<<'EOD'
+<?php
+
+namespace %g_namespace%\AdminMenus;
+
+use %g_use_libs%\AdminMenus\AbstractAdminMenu;
+
+class AdminMenuExample extends AbstractAdminMenu
+{
+}
+EOD;
+
+        $filesystemReaderMock = Mockery::mock(FileSystem::class);
+        $filesystemReaderMock->expects('read')->once()->andReturn($contents);
+        $filesystemReaderMock->expects('getRelativePath')->once()->andReturnArg(1);
+
+        $discoveredSymbols = new DiscoveredSymbols();
+
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $sut = new FileSymbolScanner($config, $discoveredSymbols, $filesystemReaderMock);
+
+        $file = Mockery::mock(File::class);
+        $file->shouldReceive('isPhpFile')->andReturnTrue();
+        $file->shouldReceive('getTargetRelativePath');
+        $file->shouldReceive('getDependency');
+        $file->shouldReceive('addDiscoveredSymbol');
+        $file->shouldReceive('getSourcePath')->andReturn('/a/path/AdminMenuExample.php');
+
+        $discoveredFiles = Mockery::mock(DiscoveredFiles::class);
+        $discoveredFiles->shouldReceive('getFiles')->andReturn([$file]);
+
+        $result = $sut->findInFiles($discoveredFiles);
+
+        self::assertEmpty($result->getDiscoveredClasses());
+    }
 }


### PR DESCRIPTION
## Problem

When a vendor package contains template files with placeholder tokens (e.g. `%g_namespace%`) that are not valid PHP, `PhpParser` throws a `\PhpParser\Error` during parsing. This error was unhandled in both `FileSymbolScanner` and `Prefixer`, causing the entire strauss run to abort with:

```
[error] Syntax error, unexpected '%' on line 11
Script @php strauss.phar --debug handling the post-install-cmd event returned with error code 1
```

A concrete example: [eightshift-libs](https://github.com/infinum/eightshift-libs) ships template files like `AdminMenuExample.php` with `namespace %g_namespace%\AdminMenus;` — intentionally invalid PHP used as CLI scaffolding templates. These are covered by `exclude_from_prefix.file_patterns` in `composer.json`, but that exclusion is applied *after* the scan phase, so the parser error fires first.

## Fix

Added `try/catch (\PhpParser\Error $e)` around all `$parser->parse()` calls in:

- `FileSymbolScanner::splitByNamespace()` — returns `[]` (no symbols discovered)
- `Prefixer::replaceConstFetchNamespaces()` — returns `$contents` unchanged
- `Prefixer::replaceFunctions()` — returns `$contents` unchanged  
- `Prefixer::prepareRelativeNamespaces()` — returns `$phpFileContent` unchanged

Files that cannot be parsed are silently skipped. This matches reasonable expectations: if a file isn't valid PHP, there's nothing to prefix.

## Test

Added `testTemplateFileWithPlaceholdersIsSkippedGracefully` to `FileSymbolScannerTest` covering the exact pattern that triggers the bug.

## Issue
https://github.com/BrianHenryIE/strauss/issues/227