### PR TITLE
# Performance improvements across the Strauss prefixing pipeline

### DIFF
--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -148,15 +148,6 @@ class ComposerPackage
 
         $composerJsonFileAbsolute = $composer->getConfig()->getConfigSource()->getName();
 
-        $pathNormalizer = FileSystem::makePathNormalizer(getcwd());
-        
-        $fsComposerAbsoluteDirectoryPath = realpath(dirname($composerJsonFileAbsolute));
-        if (false !== $fsComposerAbsoluteDirectoryPath) {
-            $fsComposerAbsoluteDirectoryPath = FileSystem::normalizeDirSeparator($fsComposerAbsoluteDirectoryPath);
-            $this->packageAbsolutePath = $fsComposerAbsoluteDirectoryPath;
-        }
-        $fsComposerAbsoluteDirectoryPath = $fsComposerAbsoluteDirectoryPath ?: FileSystem::normalizeDirSeparator(dirname($composerJsonFileAbsolute));
-
         $fsCurrentWorkingDirectory = getcwd();
         if ($fsCurrentWorkingDirectory === false) {
             /**
@@ -164,6 +155,15 @@ class ComposerPackage
              */
             throw new Exception('Could not determine working directory. Please comment out ~'.__LINE__.' in ' . __FILE__.' and see does it work regardless.');
         }
+
+        $pathNormalizer = FileSystem::makePathNormalizer($fsCurrentWorkingDirectory);
+
+        $fsComposerAbsoluteDirectoryPath = realpath(dirname($composerJsonFileAbsolute));
+        if (false !== $fsComposerAbsoluteDirectoryPath) {
+            $fsComposerAbsoluteDirectoryPath = FileSystem::normalizeDirSeparator($fsComposerAbsoluteDirectoryPath);
+            $this->packageAbsolutePath = $fsComposerAbsoluteDirectoryPath;
+        }
+        $fsComposerAbsoluteDirectoryPath = $fsComposerAbsoluteDirectoryPath ?: FileSystem::normalizeDirSeparator(dirname($composerJsonFileAbsolute));
         $fsCurrentWorkingDirectory = FileSystem::normalizeDirSeparator($fsCurrentWorkingDirectory);
 
         /** @var string $vendorAbsoluteDirectoryPath */

--- a/src/Composer/ComposerPackage.php
+++ b/src/Composer/ComposerPackage.php
@@ -9,9 +9,9 @@ namespace BrianHenryIE\Strauss\Composer;
 
 use BrianHenryIE\Strauss\Files\FileWithDependency;
 use BrianHenryIE\Strauss\Helpers\FileSystem;
-use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
+use Composer\PartialComposer;
 use Composer\Util\Platform;
 use Exception;
 
@@ -28,9 +28,9 @@ class ComposerPackage
      *
      * @see Factory::create
      *
-     * @var Composer
+     * @var PartialComposer
      */
-    protected Composer $composer;
+    protected PartialComposer $composer;
 
     /**
      * The name of the project in composer.json.
@@ -105,9 +105,7 @@ class ComposerPackage
      */
     public static function fromFile(string $absolutePath, ?array $overrideAutoload = null): ComposerPackage
     {
-        $composer = Factory::create(new NullIO(), $absolutePath, true);
-
-        return new ComposerPackage($composer, $overrideAutoload);
+        return new ComposerPackage(self::createPartialComposer($absolutePath), $overrideAutoload);
     }
 
     /**
@@ -119,21 +117,30 @@ class ComposerPackage
      */
     public static function fromComposerJsonArray(array $jsonArray, ?array $overrideAutoload = null): ComposerPackage
     {
-        $factory = new Factory();
-        $io = new NullIO();
-        $composer = $factory->createComposer($io, $jsonArray, true);
+        return new ComposerPackage(self::createPartialComposer($jsonArray), $overrideAutoload);
+    }
 
-        return new ComposerPackage($composer, $overrideAutoload);
+    /**
+     * @param string|ComposerJsonArray $composerInput
+     */
+    private static function createPartialComposer($composerInput): PartialComposer
+    {
+        $factory = new Factory();
+
+        /** @var PartialComposer $composer */
+        $composer = $factory->createComposer(new NullIO(), $composerInput, true, null, false);
+
+        return $composer;
     }
 
     /**
      * Create a PHP object to represent a composer package.
      *
-     * @param Composer $composer
+     * @param PartialComposer $composer
      * @param ?AutoloadKeyArray $overrideAutoload Optional configuration to replace the package's own autoload definition with another which Strauss can use.
      * @throws Exception
      */
-    public function __construct(Composer $composer, ?array $overrideAutoload = null)
+    public function __construct(PartialComposer $composer, ?array $overrideAutoload = null)
     {
         $this->composer = $composer;
 
@@ -163,7 +170,12 @@ class ComposerPackage
         $vendorAbsoluteDirectoryPath = $this->composer->getConfig()->get('vendor-dir');
         if (file_exists($vendorAbsoluteDirectoryPath . '/' . $this->packageName)) {
             $this->relativePath = $this->packageName;
-            $this->packageAbsolutePath = $pathNormalizer->normalizePath(realpath($vendorAbsoluteDirectoryPath . '/' . $this->packageName));
+            $resolvedPackagePath = realpath($vendorAbsoluteDirectoryPath . '/' . $this->packageName);
+            $this->packageAbsolutePath = $pathNormalizer->normalizePath(
+                false !== $resolvedPackagePath
+                    ? $resolvedPackagePath
+                    : $vendorAbsoluteDirectoryPath . '/' . $this->packageName
+            );
         // If the package is symlinked, the path will be outside the working directory.
         } elseif (0 !== strpos($fsComposerAbsoluteDirectoryPath, $fsCurrentWorkingDirectory) && 1 === preg_match('/.*[\/\\\\]([^\/\\\\]*[\/\\\\][^\/\\\\]*)[\/\\\\][^\/\\\\]*/', $vendorAbsoluteDirectoryPath, $output_array)) {
             $this->relativePath = $output_array[1];
@@ -240,12 +252,23 @@ class ComposerPackage
      */
     public function getRequiresNames(): array
     {
-        // Unset PHP, ext-*.
-        $removePhpExt = function ($element) {
-            return !( 0 === strpos($element, 'ext') || 'php' === $element );
-        };
+        return array_filter(
+            $this->requiresNames,
+            static function (string $requiredPackageName): bool {
+                return !self::isPlatformPackageName($requiredPackageName);
+            }
+        );
+    }
 
-        return array_filter($this->requiresNames, $removePhpExt);
+    public static function isPlatformPackageName(string $packageName, bool $includePhpVariants = false): bool
+    {
+        return 0 === strpos($packageName, 'ext')
+            || 'php' === $packageName
+            || (
+                $includePhpVariants
+                && 0 === strpos($packageName, 'php')
+                && false === strpos($packageName, '/')
+            );
     }
 
     public function getLicense():string

--- a/src/Console/Commands/AbstractRenamespacerCommand.php
+++ b/src/Console/Commands/AbstractRenamespacerCommand.php
@@ -133,6 +133,9 @@ abstract class AbstractRenamespacerCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * @phpstan-return Logger::DEBUG|Logger::INFO|Logger::NOTICE
+     */
     private function getMinimumMonologLevel(InputInterface $input): int
     {
         if ($this->isDryRunConfigured() || ($input->hasOption('debug') && $input->getOption('debug') !== false)) {

--- a/src/Console/Commands/AbstractRenamespacerCommand.php
+++ b/src/Console/Commands/AbstractRenamespacerCommand.php
@@ -117,14 +117,38 @@ abstract class AbstractRenamespacerCommand extends Command
             }
         }
 
+        $outputLogger = $this->getLogger($input, $output);
+        if ($outputLogger instanceof NullLogger) {
+            $this->setLogger($outputLogger);
+            return Command::SUCCESS;
+        }
+
         $logger = new Logger('logger');
         $logger->pushProcessor(new PsrLogMessageProcessor());
         $logger->pushProcessor(new RelativeFilepathLogProcessor($this->filesystem));
         $logger->pushProcessor(new PadColonColumnsLogProcessor());
-        $logger->pushHandler(new PsrHandler($this->getLogger($input, $output)));
+        $logger->pushHandler(new PsrHandler($outputLogger, $this->getMinimumMonologLevel($input)));
         $this->setLogger($logger);
 
         return Command::SUCCESS;
+    }
+
+    private function getMinimumMonologLevel(InputInterface $input): int
+    {
+        if ($this->isDryRunConfigured() || ($input->hasOption('debug') && $input->getOption('debug') !== false)) {
+            return Logger::DEBUG;
+        }
+
+        if ($input->hasOption('info') && $input->getOption('info') !== false) {
+            return Logger::INFO;
+        }
+
+        return Logger::NOTICE;
+    }
+
+    private function isDryRunConfigured(): bool
+    {
+        return isset($this->config) && $this->config->isDryRun();
     }
 
     /**
@@ -165,7 +189,7 @@ abstract class AbstractRenamespacerCommand extends Command
     protected function getLogger(InputInterface $input, OutputInterface $output): LoggerInterface
     {
         // If a subclass has a config and it is a dry-run, increase verbosity
-        $isDryRun = property_exists($this, 'config') && isset($this->config) && method_exists($this->config, 'isDryRun') && $this->config->isDryRun();
+        $isDryRun = $this->isDryRunConfigured();
 
         // Who would want to dry-run without output?
         if (!$isDryRun && $input->hasOption('silent') && $input->getOption('silent') !== false) {

--- a/src/Console/Commands/DependenciesCommand.php
+++ b/src/Console/Commands/DependenciesCommand.php
@@ -460,16 +460,7 @@ class DependenciesCommand extends AbstractRenamespacerCommand
      */
     protected function generateAutoloader(): void
     {
-        if (isset($this->projectComposerPackage->getAutoload()['classmap'])
-            && in_array(
-                $this->config->getAbsoluteTargetDirectory(),
-                array_map(
-                    fn(string $entry) => trim($entry, '\\/'),
-                    $this->projectComposerPackage->getAutoload()['classmap']
-                ),
-                true
-            )
-        ) {
+        if ($this->shouldSkipAutoloaderGeneration()) {
             $this->logger->notice('Skipping autoloader generation as target directory is in Composer classmap. Run `composer dump-autoload`.');
             return;
         }
@@ -493,6 +484,23 @@ class DependenciesCommand extends AbstractRenamespacerCommand
         );
 
         $classmap->generate($this->flatDependencyTree, $this->discoveredSymbols);
+    }
+
+    private function shouldSkipAutoloaderGeneration(): bool
+    {
+        $autoload = $this->projectComposerPackage->getAutoload();
+        if (!isset($autoload['classmap'])) {
+            return false;
+        }
+
+        return in_array(
+            $this->config->getAbsoluteTargetDirectory(),
+            array_map(
+                fn(string $entry) => trim($entry, '\\/'),
+                $autoload['classmap']
+            ),
+            true
+        );
     }
 
     /**
@@ -542,11 +550,41 @@ class DependenciesCommand extends AbstractRenamespacerCommand
         // This will check the config to check should it delete or not.
         $cleanup->deleteFiles($this->flatDependencyTree, $this->discoveredFiles);
 
-        $cleanup->cleanupVendorInstalledJson($this->flatDependencyTree, $this->discoveredSymbols);
+        $this->cleanupInstalledJson();
         if ($this->config->isDeleteVendorFiles() || $this->config->isDeleteVendorPackages()) {
             // Rebuild the autoloader after cleanup.
             // This is needed because cleanup may have deleted files that were in the autoloader.
             $cleanup->rebuildVendorAutoloader();
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function cleanupInstalledJson(): void
+    {
+        $shouldCleanTarget = !$this->config->isTargetDirectoryVendor()
+            && (!$this->config->isClassmapOutput() || $this->shouldSkipAutoloaderGeneration());
+        $shouldCleanVendor = $this->config->isTargetDirectoryVendor()
+            || $this->config->isDeleteVendorFiles()
+            || $this->config->isDeleteVendorPackages();
+
+        if (!$shouldCleanTarget && !$shouldCleanVendor) {
+            return;
+        }
+
+        $installedJson = new InstalledJson(
+            $this->config,
+            $this->filesystem,
+            $this->logger
+        );
+
+        if ($shouldCleanTarget) {
+            $installedJson->cleanTargetDirInstalledJson($this->flatDependencyTree, $this->discoveredSymbols);
+        }
+
+        if ($shouldCleanVendor) {
+            $installedJson->cleanupVendorInstalledJson($this->flatDependencyTree, $this->discoveredSymbols);
         }
     }
 }

--- a/src/Helpers/FileSystem.php
+++ b/src/Helpers/FileSystem.php
@@ -384,7 +384,8 @@ class FileSystem implements FilesystemOperator, FlysystemBackCompatInterface, Pa
             return true;
         }
 
-        if (realpath($osPath) !== $osPath) {
+        $realPath = realpath($osPath);
+        if (false !== $realPath && self::normalizeDirSeparator($realPath) !== self::normalizeDirSeparator($osPath)) {
             return true;
         }
 
@@ -421,16 +422,25 @@ class FileSystem implements FilesystemOperator, FlysystemBackCompatInterface, Pa
     public function makeAbsolute(string $path): string
     {
         $normalizedPath = self::normalizeDirSeparator($path);
+        $normalizedPath = preg_replace('#^([a-zA-Z]):/+#', '$1:/', $normalizedPath) ?? $normalizedPath;
+        if (1 === preg_match('#^[a-zA-Z]:/#', $normalizedPath)) {
+            return self::normalizeDirSeparator($normalizedPath, DIRECTORY_SEPARATOR);
+        }
+
+        if (1 === preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]{1,}://#', $normalizedPath)) {
+            return $normalizedPath;
+        }
+
         $normalizedRoot = self::normalizeDirSeparator(self::getFsRoot($this->workingDir));
 
         if (str_starts_with(strtoupper($normalizedPath), $normalizedRoot)) {
-            return self::normalizeDirSeparator($path, DIRECTORY_SEPARATOR);
+            return self::normalizeDirSeparator($normalizedPath, DIRECTORY_SEPARATOR);
         }
 
-        $prefixed = $this->pathPrefixer->prefixPath($this->normalizePath($path));
-
-        if ($this->flysystem instanceof ReadOnlyFileSystem) {
-            return str_replace(':/', '://', $prefixed);
+        $prefixed = self::normalizeDirSeparator($this->pathPrefixer->prefixPath($this->normalizePath($path)));
+        $prefixed = preg_replace('#^([a-zA-Z][a-zA-Z0-9+.-]{1,}):/(?!/)#', '$1://', $prefixed) ?? $prefixed;
+        if (1 === preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]{1,}://#', $prefixed)) {
+            return $prefixed;
         }
 
         return self::normalizeDirSeparator($prefixed, DIRECTORY_SEPARATOR);

--- a/src/Pipeline/Cleanup/Cleanup.php
+++ b/src/Pipeline/Cleanup/Cleanup.php
@@ -183,24 +183,7 @@ class Cleanup
     {
         $this->logger->info('Deleting empty directories.');
 
-        $sourceFiles = array_map(
-            fn($file) => $file->getSourcePath(),
-            $files
-        );
-
-        // Get the root folders of the moved files.
-        $rootSourceDirectories = [];
-        foreach ($sourceFiles as $sourceFile) {
-            $arr = explode("/", $sourceFile, 2);
-            $dir = $arr[0];
-            $rootSourceDirectories[ $dir ] = $dir;
-        }
-        $rootSourceDirectories = array_map(
-            function (string $path): string {
-                return $this->config->getAbsoluteVendorDirectory() . '/' . $path;
-            },
-            array_keys($rootSourceDirectories)
-        );
+        $rootSourceDirectories = $this->getRootSourceDirectories($files);
 
         foreach ($rootSourceDirectories as $rootSourceDirectory) {
             if (!$this->filesystem->directoryExists($rootSourceDirectory) || is_link($rootSourceDirectory)) {
@@ -209,23 +192,23 @@ class Cleanup
 
             $dirList = $this->filesystem->listContents($rootSourceDirectory, true);
 
-            $allFilePaths = array_map(
-                fn($file) => $file->path(),
-                $dirList->toArray()
-            );
+            $allDirectoryPaths = [];
+            foreach ($dirList as $entry) {
+                if ($entry->isDir()) {
+                    $allDirectoryPaths[] = $entry->path();
+                }
+            }
 
             // Sort by longest path first, so subdirectories are deleted before the parent directories are checked.
             usort(
-                $allFilePaths,
-                fn($a, $b) => count(explode('/', $b)) - count(explode('/', $a))
+                $allDirectoryPaths,
+                fn($a, $b) => substr_count($b, '/') - substr_count($a, '/')
             );
 
-            foreach ($allFilePaths as $filePath) {
-                if ($this->filesystem->directoryExists($filePath)
-                    && $this->filesystem->isDirectoryEmpty($filePath)
-                ) {
-                    $this->logger->debug('Deleting empty directory ' . $filePath);
-                    $this->filesystem->deleteDirectory($filePath);
+            foreach ($allDirectoryPaths as $directoryPath) {
+                if ($this->filesystem->isDirectoryEmpty($directoryPath)) {
+                    $this->logger->debug('Deleting empty directory ' . $directoryPath);
+                    $this->filesystem->deleteDirectory($directoryPath);
                 }
             }
         }
@@ -239,6 +222,34 @@ class Cleanup
 //            }
 //        }
         $this->logger->debug('Finished Cleanup::deleteEmptyDirectories()');
+    }
+
+    /**
+     * @param FileBase[] $files
+     * @return string[]
+     */
+    private function getRootSourceDirectories(array $files): array
+    {
+        $vendorDirectory = rtrim(FileSystem::normalizeDirSeparator($this->config->getAbsoluteVendorDirectory()), '/');
+        $rootSourceDirectories = [];
+
+        foreach ($files as $file) {
+            $vendorRelativePath = $this->filesystem->getRelativePath($vendorDirectory, $file->getSourcePath());
+            $vendorRelativePath = ltrim(FileSystem::normalizeDirSeparator($vendorRelativePath), '/');
+
+            if ($vendorRelativePath === '' || str_starts_with($vendorRelativePath, '../')) {
+                continue;
+            }
+
+            $rootDirectory = explode('/', $vendorRelativePath, 2)[0] ?? '';
+            if ($rootDirectory === '') {
+                continue;
+            }
+
+            $rootSourceDirectories[$rootDirectory] = $vendorDirectory . '/' . $rootDirectory;
+        }
+
+        return array_values($rootSourceDirectories);
     }
 
     /**

--- a/src/Pipeline/Cleanup/InstalledJson.php
+++ b/src/Pipeline/Cleanup/InstalledJson.php
@@ -51,6 +51,12 @@ class InstalledJson
 
     protected FileSystem $filesystem;
 
+    /** @var array<string,bool> */
+    private array $existsCache = [];
+
+    /** @var array<string,bool> */
+    private array $directoryExistsCache = [];
+
     public function __construct(
         CleanupConfigInterface $config,
         FileSystem $filesystem,
@@ -98,10 +104,7 @@ class InstalledJson
     protected function getJsonFile(string $vendorDir): JsonFile
     {
         $installedJsonFile = new JsonFile(
-            sprintf(
-                '%s/composer/installed.json',
-                $this->filesystem->makeAbsolute($vendorDir)
-            )
+            $this->filesystem->makeAbsolute(rtrim($vendorDir, '/\\') . '/composer/installed.json')
         );
         if (!$installedJsonFile->exists()) {
             if (!$this->config->isDryRun()) {
@@ -128,15 +131,17 @@ class InstalledJson
      */
     protected function updatePackagePaths(array $installedJsonArray, array $flatDependencyTree, string $path, array $excludedPackageNames = []): array
     {
+        $dependencyPackageNames = array_fill_keys(array_keys($flatDependencyTree), true);
+        $excludedPackageNamesLookup = array_fill_keys($excludedPackageNames, true);
 
         foreach ($installedJsonArray['packages'] as $key => $package) {
-            if (in_array($package['name'], $excludedPackageNames, true)) {
+            if (isset($excludedPackageNamesLookup[$package['name']])) {
                 unset($installedJsonArray['packages'][$key]);
                 continue;
             }
 
             // Skip packages that were never copied in the first place.
-            if (!in_array($package['name'], array_keys($flatDependencyTree))) {
+            if (!isset($dependencyPackageNames[$package['name']])) {
                 $this->logger->debug('Skipping package: ' . $package['name']);
                 continue;
             }
@@ -144,12 +149,12 @@ class InstalledJson
 
             // `composer/` is here because the install-path is relative to the `vendor/composer` directory.
             $packageDir = $path . '/composer/' . $package['install-path'];
-            if (!$this->filesystem->directoryExists($packageDir)) {
+            if (!$this->directoryExists($packageDir)) {
                 $this->logger->debug('Package directory does not exist at : ' . $packageDir);
 
                 $newInstallPath = $path . '/'.str_replace('../', '', $package['install-path']);
 
-                if (!$this->filesystem->directoryExists($newInstallPath)) {
+                if (!$this->directoryExists($newInstallPath)) {
                     unset($installedJsonArray['packages'][$key]);
                     $this->logger->info('Package directory does not exist: ' . $newInstallPath);
                     continue;
@@ -174,7 +179,7 @@ class InstalledJson
      */
     protected function pathExistsInPackage(string $vendorDir, array $packageArray, string $relativePath): bool
     {
-        return $this->filesystem->exists(
+        return $this->exists(
             $vendorDir . '/composer/' . $packageArray['install-path'] . '/' . $relativePath
         );
     }
@@ -198,7 +203,7 @@ class InstalledJson
             }
             // delete_vendor_files
             $path = $vendorDir . '/composer/' . $packageArray['install-path'];
-            $pathExists = $this->filesystem->directoryExists($path);
+            $pathExists = $this->directoryExists($path);
             // delete_vendor_packages
             if (!$pathExists) {
                 $this->logger->info(
@@ -316,6 +321,7 @@ class InstalledJson
      */
     protected function removeMovedPackagesAutoloadKeyFromTargetDirInstalledJson(array $installedJsonArray, array $flatDependencyTree, string $installedJsonPath): array
     {
+        $dependencyPackageNames = array_fill_keys(array_keys($flatDependencyTree), true);
         /**
          * @var int $key
          * @var InstalledJsonPackageArray $packageArray
@@ -325,7 +331,7 @@ class InstalledJson
 
             $remove = false;
 
-            if (!in_array($packageName, array_keys($flatDependencyTree))) {
+            if (!isset($dependencyPackageNames[$packageName])) {
                 // If it's not a package we were ever considering copying, then we can remove it.
                 $remove = true;
             } else {
@@ -375,15 +381,19 @@ class InstalledJson
             foreach ($autoload_key as $type => $autoload) {
                 switch ($type) {
                     case 'psr-0':
-                        /** @var string $relativePath */
-                        foreach (array_values((array) $autoload_key[$type]) as $relativePath) {
-                            $packageRelativePath = $package['install-path'];
-                            if (1 === preg_match('#.*'.preg_quote($this->config->getAbsoluteTargetDirectory(), '#').'/(.*)#', $packageRelativePath, $matches)) {
-                                $packageRelativePath = $matches[1];
-                            }
-                            // Convert psr-0 autoloading to classmap autoloading
-                            if ($this->filesystem->directoryExists($this->config->getAbsoluteTargetDirectory() . '/composer/' . $packageRelativePath . $relativePath)) {
-                                $autoload_key['classmap'][] = $relativePath;
+                        foreach ($autoload_key[$type] ?? [] as $paths) {
+                            foreach ((array) $paths as $relativePath) {
+                                if (!is_string($relativePath)) {
+                                    continue;
+                                }
+                                $packageRelativePath = $package['install-path'];
+                                if (1 === preg_match('#.*'.preg_quote($this->config->getAbsoluteTargetDirectory(), '#').'/(.*)#', $packageRelativePath, $matches)) {
+                                    $packageRelativePath = $matches[1];
+                                }
+                                // Convert psr-0 autoloading to classmap autoloading
+                                if ($this->directoryExists($this->config->getAbsoluteTargetDirectory() . '/composer/' . $packageRelativePath . $relativePath)) {
+                                    $autoload_key['classmap'][] = $relativePath;
+                                }
                             }
                         }
                         // Intentionally fall through
@@ -468,6 +478,7 @@ class InstalledJson
     public function cleanTargetDirInstalledJson(array $flatDependencyTree, DiscoveredSymbols $discoveredSymbols): void
     {
         $this->logger->debug('InstalledJson::cleanTargetDirInstalledJson()');
+        $this->resetPathCaches();
 
         $targetDir = $this->config->getAbsoluteTargetDirectory();
         try {
@@ -507,8 +518,9 @@ class InstalledJson
 
         $installedJsonArray = $this->updateNamespaces($installedJsonArray, $discoveredSymbols);
 
+        $dependencyPackageNames = array_fill_keys(array_keys($flatDependencyTree), true);
         foreach ($installedJsonArray['packages'] as $index => $package) {
-            if (!in_array($package['name'], array_keys($flatDependencyTree))) {
+            if (!isset($dependencyPackageNames[$package['name']])) {
                 unset($installedJsonArray['packages'][$index]);
             }
         }
@@ -541,6 +553,7 @@ class InstalledJson
     public function cleanupVendorInstalledJson(array $flatDependencyTree, DiscoveredSymbols $discoveredSymbols): void
     {
         $this->logger->debug('InstalledJson::cleanupVendorInstalledJson()');
+        $this->resetPathCaches();
 
         $vendorDir = $this->config->getAbsoluteVendorDirectory();
 
@@ -571,5 +584,29 @@ class InstalledJson
         }
 
         $this->logger->debug('Finished InstalledJson::cleanupVendorInstalledJson()');
+    }
+
+    private function resetPathCaches(): void
+    {
+        $this->existsCache = [];
+        $this->directoryExistsCache = [];
+    }
+
+    private function exists(string $path): bool
+    {
+        $path = FileSystem::normalizeDirSeparator($path);
+        if (!array_key_exists($path, $this->existsCache)) {
+            $this->existsCache[$path] = $this->filesystem->exists($path);
+        }
+        return $this->existsCache[$path];
+    }
+
+    private function directoryExists(string $path): bool
+    {
+        $path = FileSystem::normalizeDirSeparator($path);
+        if (!array_key_exists($path, $this->directoryExistsCache)) {
+            $this->directoryExistsCache[$path] = $this->filesystem->directoryExists($path);
+        }
+        return $this->directoryExistsCache[$path];
     }
 }

--- a/src/Pipeline/Cleanup/InstalledJson.php
+++ b/src/Pipeline/Cleanup/InstalledJson.php
@@ -381,7 +381,7 @@ class InstalledJson
             foreach ($autoload_key as $type => $autoload) {
                 switch ($type) {
                     case 'psr-0':
-                        foreach ($autoload_key[$type] ?? [] as $paths) {
+                        foreach ($autoload as $paths) {
                             foreach ((array) $paths as $relativePath) {
                                 if (!is_string($relativePath)) {
                                     continue;

--- a/src/Pipeline/DependenciesEnumerator.php
+++ b/src/Pipeline/DependenciesEnumerator.php
@@ -225,9 +225,7 @@ class DependenciesEnumerator
     protected function removeVirtualPackagesFilter(string $requiredPackageName): bool
     {
         return ! (
-            0 === strpos($requiredPackageName, 'ext')
-            // E.g. `php`, `php-64bit`.
-            || (0 === strpos($requiredPackageName, 'php') && false === strpos($requiredPackageName, '/'))
+            ComposerPackage::isPlatformPackageName($requiredPackageName, true)
             || in_array($requiredPackageName, $this->virtualPackages)
         );
     }

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -52,7 +52,11 @@ class FileEnumerator
             $this->logger->info("Scanning for files for package {packageName}", ['packageName' => $dependency->getPackageName()]);
             /** @var string $dependencyPackageAbsolutePath */
             $dependencyPackageAbsolutePath = $dependency->getPackageAbsolutePath();
-            $this->compileFileListForPaths([$dependencyPackageAbsolutePath], $dependency);
+            $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths([$dependencyPackageAbsolutePath]);
+
+            foreach ($absoluteFilePaths as $sourceAbsolutePath) {
+                $this->addFile($sourceAbsolutePath, $dependency);
+            }
         }
 
         $this->discoveredFiles->sort();

--- a/src/Pipeline/FileSymbolScanner.php
+++ b/src/Pipeline/FileSymbolScanner.php
@@ -66,6 +66,13 @@ class FileSymbolScanner
     protected ?Parser $parser = null;
     protected ?Standard $prettyPrinter = null;
 
+    private ?string $namespaceTokenCacheContents = null;
+
+    /**
+     * @var array<int, array<int, mixed>|string>|null
+     */
+    private ?array $namespaceTokenCacheTokens = null;
+
     /**
      * @var array<string,bool>
      */
@@ -217,14 +224,24 @@ class FileSymbolScanner
      */
     protected function splitByNamespace(string $contents):array
     {
-        $namespaceDeclarations = $this->getNamespaceDeclarations($contents);
+        $this->namespaceTokenCacheContents = $contents;
+        $this->namespaceTokenCacheTokens = token_get_all($contents);
+
+        try {
+            $namespaceDeclarations = $this->getNamespaceDeclarations($contents);
+            $hasMalformedNamespaceDeclaration = count($namespaceDeclarations) === 0
+                && $this->hasMalformedNamespaceDeclaration($contents);
+        } finally {
+            $this->namespaceTokenCacheContents = null;
+            $this->namespaceTokenCacheTokens = null;
+        }
 
         if (count($namespaceDeclarations) === 0) {
-            if ($this->hasMalformedNamespaceDeclaration($contents)) {
+            if ($hasMalformedNamespaceDeclaration) {
                 return [];
             }
 
-            return ['\\' => '<?php' . PHP_EOL . PHP_EOL . $contents];
+            return ['\\' => $this->ensurePhpOpeningTag($contents)];
         }
 
         if (count($namespaceDeclarations) === 1) {
@@ -246,7 +263,7 @@ class FileSymbolScanner
                     if (count($ast) === 1) {
                         $result['\\'] = $contents;
                     } else {
-                        $result['\\'] = '<?php' . PHP_EOL . PHP_EOL . $this->getPrettyPrinter()->prettyPrintFile($rootNode->stmts);
+                        $result['\\'] = $this->getPrettyPrinter()->prettyPrintFile($rootNode->stmts);
                     }
                 } else {
                     $namespaceName = $rootNode->name->name;
@@ -254,7 +271,7 @@ class FileSymbolScanner
                         $result[$namespaceName] = $contents;
                     } else {
                         // This was failing for `phpoffice/phpspreadsheet/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php`
-                        $result[$namespaceName] = '<?php' . PHP_EOL . PHP_EOL . 'namespace ' . $namespaceName . ';' . PHP_EOL . PHP_EOL . $this->getPrettyPrinter()->prettyPrintFile($rootNode->stmts);
+                        $result[$namespaceName] = '<?php' . PHP_EOL . PHP_EOL . 'namespace ' . $namespaceName . ';' . PHP_EOL . PHP_EOL . $this->getPrettyPrinter()->prettyPrint($rootNode->stmts);
                     }
                 }
             }
@@ -262,10 +279,20 @@ class FileSymbolScanner
 
         // TODO: is this necessary?
         if (empty($result)) {
-            $result['\\'] = '<?php' . PHP_EOL . PHP_EOL . $contents;
+            $result['\\'] = $this->ensurePhpOpeningTag($contents);
         }
 
         return $result;
+    }
+
+    private function ensurePhpOpeningTag(string $contents): string
+    {
+        $trimmedContents = ltrim($contents);
+        if (0 === strpos($trimmedContents, '<?')) {
+            return $contents;
+        }
+
+        return '<?php' . PHP_EOL . PHP_EOL . $contents;
     }
 
     /**
@@ -415,7 +442,7 @@ class FileSymbolScanner
      */
     protected function getNamespaceDeclarations(string $contents): array
     {
-        $tokens = token_get_all($contents);
+        $tokens = $this->getNamespaceTokens($contents);
 
         $declarations = [];
         $tokenCount = count($tokens);
@@ -467,7 +494,7 @@ class FileSymbolScanner
 
     protected function hasMalformedNamespaceDeclaration(string $contents): bool
     {
-        $tokens = token_get_all($contents);
+        $tokens = $this->getNamespaceTokens($contents);
         $tokenCount = count($tokens);
         for ($i = 0; $i < $tokenCount; $i++) {
             $token = $tokens[$i];
@@ -494,6 +521,18 @@ class FileSymbolScanner
         }
 
         return false;
+    }
+
+    /**
+     * @return array<int, array<int, mixed>|string>
+     */
+    private function getNamespaceTokens(string $contents): array
+    {
+        if ($this->namespaceTokenCacheTokens !== null && $this->namespaceTokenCacheContents === $contents) {
+            return $this->namespaceTokenCacheTokens;
+        }
+
+        return token_get_all($contents);
     }
 
     /**

--- a/src/Pipeline/FileSymbolScanner.php
+++ b/src/Pipeline/FileSymbolScanner.php
@@ -22,7 +22,11 @@ use BrianHenryIE\Strauss\Types\InterfaceSymbol;
 use BrianHenryIE\Strauss\Types\NamespaceSymbol;
 use BrianHenryIE\Strauss\Types\TraitSymbol;
 use League\Flysystem\FilesystemException;
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserContainer;
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserErrorHandler;
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\Utils;
 use PhpParser\Node;
+use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Psr\Log\LoggerAwareTrait;
@@ -32,10 +36,23 @@ use BrianHenryIE\SimplePhpParser\Model\PHPClass;
 use BrianHenryIE\SimplePhpParser\Model\PHPConst;
 use BrianHenryIE\SimplePhpParser\Model\PHPFunction;
 use BrianHenryIE\SimplePhpParser\Parsers\PhpCodeParser;
+use BrianHenryIE\SimplePhpParser\Parsers\Visitors\ASTVisitor;
 
 class FileSymbolScanner
 {
     use LoggerAwareTrait;
+
+    /**
+     * @var array<class-string<DiscoveredSymbol>,string>
+     */
+    private const SYMBOL_LOG_TYPES = [
+        ClassSymbol::class => 'class',
+        ConstantSymbol::class => 'constant',
+        FunctionSymbol::class => 'function',
+        InterfaceSymbol::class => 'interface',
+        NamespaceSymbol::class => 'namespace',
+        TraitSymbol::class => 'trait',
+    ];
 
     protected DiscoveredSymbols $discoveredSymbols;
 
@@ -46,10 +63,18 @@ class FileSymbolScanner
     /** @var string[] */
     protected array $builtIns = [];
 
+    protected ?Parser $parser = null;
+    protected ?Standard $prettyPrinter = null;
+
     /**
-     * @var string[]
+     * @var array<string,bool>
      */
     protected array $loggedSymbols = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    protected array $builtInsLookup = [];
 
     /**
      * FileScanner constructor.
@@ -73,18 +98,19 @@ class FileSymbolScanner
     {
         $this->discoveredSymbols->add($symbol);
 
-        $level = in_array($symbol->getOriginalSymbol(), $this->loggedSymbols) ? 'debug' : 'info';
-        $newText = in_array($symbol->getOriginalSymbol(), $this->loggedSymbols) ? '' : 'new ';
+        $isAlreadyLogged = isset($this->loggedSymbols[$symbol->getOriginalSymbol()]);
+        $level = $isAlreadyLogged ? 'debug' : 'info';
+        $newText = $isAlreadyLogged ? '' : 'new ';
 
-        $this->loggedSymbols[] = $symbol->getOriginalSymbol();
+        $this->loggedSymbols[$symbol->getOriginalSymbol()] = true;
+        $symbolType = self::SYMBOL_LOG_TYPES[get_class($symbol)] ?? 'symbol';
 
         $this->logger->log(
             $level,
             sprintf(
                 "Found %s%s:::%s",
                 $newText,
-                // From `BrianHenryIE\Strauss\Types\TraitSymbol` -> `trait`
-                strtolower(str_replace('Symbol', '', array_reverse(explode('\\', get_class($symbol)))[0])),
+                $symbolType,
                 $symbol->getOriginalSymbol()
             )
         );
@@ -95,16 +121,21 @@ class FileSymbolScanner
      */
     public function findInFiles(DiscoveredFiles $files): DiscoveredSymbols
     {
+        $packagesToPrefixLookup = array_fill_keys(array_keys($this->config->getPackagesToPrefix()), true);
+        $projectDirectory = $this->config->getProjectDirectory();
+
         foreach ($files->getFiles() as $file) {
-            if ($file instanceof FileWithDependency && !in_array($file->getDependency()->getPackageName(), array_keys($this->config->getPackagesToPrefix()))) {
+            if ($file instanceof FileWithDependency
+                && !isset($packagesToPrefixLookup[$file->getDependency()->getPackageName()])
+            ) {
                 $doPrefix = false;
                 $file->setDoPrefix($doPrefix);
             }
 
-            $relativeFilePath = $this->filesystem->getRelativePath(
-                $this->config->getProjectDirectory(),
-                $file->getSourcePath()
-            );
+            $relativeFilePath =
+                $file instanceof FileWithDependency
+                    ? $file->getVendorRelativePath()
+                    : $this->filesystem->getRelativePath($projectDirectory, $file->getSourcePath());
 
             if (!$file->isPhpFile()) {
                 $file->setDoPrefix(false);
@@ -126,12 +157,12 @@ class FileSymbolScanner
     protected function find(string $contents, FileBase $file, ?ComposerPackage $package = null): void
     {
         $namespaces = $this->splitByNamespace($contents);
+        PhpCodeParser::$classExistsAutoload = false;
 
         foreach ($namespaces as $namespaceName => $contents) {
-            $this->addDiscoveredNamespaceChange($namespaceName, $file, $package);
+            $phpCode = $this->parsePhpCode($contents);
 
-            PhpCodeParser::$classExistsAutoload = false;
-            $phpCode = PhpCodeParser::getFromString($contents);
+            $this->addDiscoveredNamespaceChange($namespaceName, $file, $package);
 
             /** @var PHPClass[] $phpClasses */
             $phpClasses = $phpCode->getClasses();
@@ -152,7 +183,7 @@ class FileSymbolScanner
             /** @var PHPFunction[] $phpFunctions */
             $phpFunctions = $phpCode->getFunctions();
             foreach ($phpFunctions as $functionName => $function) {
-                if (in_array($functionName, $this->getBuiltIns())) {
+                if ($this->isBuiltInSymbol($functionName)) {
                     continue;
                 }
                 $functionSymbol = new FunctionSymbol($functionName, $file, $namespaceName, $package);
@@ -186,12 +217,25 @@ class FileSymbolScanner
      */
     protected function splitByNamespace(string $contents):array
     {
+        $namespaceDeclarations = $this->getNamespaceDeclarations($contents);
+
+        if (count($namespaceDeclarations) === 0) {
+            if ($this->hasMalformedNamespaceDeclaration($contents)) {
+                return [];
+            }
+
+            return ['\\' => '<?php' . PHP_EOL . PHP_EOL . $contents];
+        }
+
+        if (count($namespaceDeclarations) === 1) {
+            $namespaceName = $namespaceDeclarations[0] ?? '\\';
+            $namespaceName = empty($namespaceName) ? '\\' : $namespaceName;
+            return [$namespaceName => $contents];
+        }
+
         $result = [];
-
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
-
         try {
-            $ast = $parser->parse(trim($contents)) ?? [];
+            $ast = $this->getParser()->parse(trim($contents)) ?? [];
         } catch (\PhpParser\Error $e) {
             return [];
         }
@@ -202,7 +246,7 @@ class FileSymbolScanner
                     if (count($ast) === 1) {
                         $result['\\'] = $contents;
                     } else {
-                        $result['\\'] = '<?php' . PHP_EOL . PHP_EOL . (new Standard())->prettyPrintFile($rootNode->stmts);
+                        $result['\\'] = '<?php' . PHP_EOL . PHP_EOL . $this->getPrettyPrinter()->prettyPrintFile($rootNode->stmts);
                     }
                 } else {
                     $namespaceName = $rootNode->name->name;
@@ -210,7 +254,7 @@ class FileSymbolScanner
                         $result[$namespaceName] = $contents;
                     } else {
                         // This was failing for `phpoffice/phpspreadsheet/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php`
-                        $result[$namespaceName] = '<?php' . PHP_EOL . PHP_EOL . 'namespace ' . $namespaceName . ';' . PHP_EOL . PHP_EOL . (new Standard())->prettyPrintFile($rootNode->stmts);
+                        $result[$namespaceName] = '<?php' . PHP_EOL . PHP_EOL . 'namespace ' . $namespaceName . ';' . PHP_EOL . PHP_EOL . $this->getPrettyPrinter()->prettyPrintFile($rootNode->stmts);
                     }
                 }
             }
@@ -241,7 +285,7 @@ class FileSymbolScanner
         array $interfaces
     ): void {
         // TODO: This should be included but marked not to prefix.
-        if (in_array($fqdnClassname, $this->getBuiltIns())) {
+        if ($this->isBuiltInSymbol($fqdnClassname)) {
             return;
         }
 
@@ -314,5 +358,171 @@ class FileSymbolScanner
         );
 
         $this->builtIns = $flatArray;
+        $this->builtInsLookup = array_fill_keys($this->builtIns, true);
+    }
+
+    protected function isBuiltInSymbol(string $symbolName): bool
+    {
+        if (empty($this->builtInsLookup)) {
+            $this->loadBuiltIns();
+        }
+
+        return isset($this->builtInsLookup[$symbolName]);
+    }
+
+    protected function getParser(): Parser
+    {
+        return $this->parser ??= (new ParserFactory())->createForNewestSupportedVersion();
+    }
+
+    protected function getPrettyPrinter(): Standard
+    {
+        return $this->prettyPrinter ??= new Standard();
+    }
+
+    protected function parsePhpCode(string $contents): ParserContainer
+    {
+        $parserContainer = new ParserContainer();
+        $visitor = new ASTVisitor($parserContainer);
+
+        $result = PhpCodeParser::process($contents, null, $parserContainer, $visitor);
+        if (!$result instanceof ParserContainer && $result instanceof ParserErrorHandler) {
+            return $parserContainer;
+        }
+
+        $interfaces = $parserContainer->getInterfaces();
+        foreach ($interfaces as &$interface) {
+            $interface->parentInterfaces = $visitor->combineParentInterfaces($interface);
+        }
+        unset($interface);
+
+        $classes = &$parserContainer->getClassesByReference();
+        foreach ($classes as &$class) {
+            $class->interfaces = Utils::flattenArray(
+                $visitor->combineImplementedInterfaces($class),
+                false
+            );
+        }
+        unset($class);
+
+        return $parserContainer;
+    }
+
+    /**
+     * Collect declared namespaces in source order. Namespace operators (namespace\foo) are ignored.
+     *
+     * @return array<int,string|null> Null indicates the explicit global namespace.
+     */
+    protected function getNamespaceDeclarations(string $contents): array
+    {
+        $tokens = token_get_all($contents);
+
+        $declarations = [];
+        $tokenCount = count($tokens);
+        for ($i = 0; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+
+            if (!is_array($token) || $token[0] !== T_NAMESPACE) {
+                continue;
+            }
+
+            $nextIndex = $this->nextSignificantTokenIndex($tokens, $i + 1);
+            if (is_null($nextIndex)) {
+                continue;
+            }
+
+            $next = $tokens[$nextIndex];
+            if (is_string($next) && ($next === ';' || $next === '{')) {
+                $declarations[] = null;
+                continue;
+            }
+
+            $namespaceName = '';
+            while (!is_null($nextIndex)) {
+                $current = $tokens[$nextIndex];
+
+                if (is_array($current) && $this->isNamespaceNameToken($current[0])) {
+                    $namespaceName .= $current[1];
+                    $nextIndex = $this->nextSignificantTokenIndex($tokens, $nextIndex + 1);
+                    continue;
+                }
+
+                if (is_string($current) && $current === '\\') {
+                    $namespaceName .= '\\';
+                    $nextIndex = $this->nextSignificantTokenIndex($tokens, $nextIndex + 1);
+                    continue;
+                }
+
+                if (is_string($current) && ($current === ';' || $current === '{')) {
+                    if ($namespaceName !== '') {
+                        $declarations[] = trim($namespaceName, '\\');
+                    }
+                }
+                break;
+            }
+        }
+
+        return $declarations;
+    }
+
+    protected function hasMalformedNamespaceDeclaration(string $contents): bool
+    {
+        $tokens = token_get_all($contents);
+        $tokenCount = count($tokens);
+        for ($i = 0; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+
+            if (!is_array($token) || $token[0] !== T_NAMESPACE) {
+                continue;
+            }
+
+            $nextIndex = $this->nextSignificantTokenIndex($tokens, $i + 1);
+            if (is_null($nextIndex)) {
+                continue;
+            }
+
+            $next = $tokens[$nextIndex];
+            if (is_string($next) && ($next === ';' || $next === '{')) {
+                continue;
+            }
+
+            if (is_array($next) && $this->isNamespaceNameToken($next[0])) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, array<int, mixed>|string> $tokens
+     */
+    protected function nextSignificantTokenIndex(array $tokens, int $start): ?int
+    {
+        $tokenCount = count($tokens);
+        for ($i = $start; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $i;
+        }
+
+        return null;
+    }
+
+    protected function isNamespaceNameToken(int $tokenType): bool
+    {
+        if ($tokenType === T_STRING || $tokenType === T_NS_SEPARATOR) {
+            return true;
+        }
+
+        return
+            (defined('T_NAME_QUALIFIED') && $tokenType === T_NAME_QUALIFIED)
+            || (defined('T_NAME_FULLY_QUALIFIED') && $tokenType === T_NAME_FULLY_QUALIFIED)
+            || (defined('T_NAME_RELATIVE') && $tokenType === T_NAME_RELATIVE);
     }
 }

--- a/src/Pipeline/Prefixer.php
+++ b/src/Pipeline/Prefixer.php
@@ -355,9 +355,7 @@ class Prefixer
         foreach ($replacementContext['namespaceChangesStrings'] as $originalNamespace => $replacementNamespace) {
             $escapedNamespace = str_replace('\\', '\\\\', $originalNamespace);
             if (strpos($contents, $originalNamespace) === false
-                && strpos($contents, '\\' . $originalNamespace) === false
                 && strpos($contents, $escapedNamespace) === false
-                && strpos($contents, '\\\\' . $escapedNamespace) === false
             ) {
                 continue;
             }

--- a/src/Pipeline/Prefixer.php
+++ b/src/Pipeline/Prefixer.php
@@ -24,6 +24,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
+use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Psr\Log\LoggerAwareTrait;
@@ -44,6 +45,10 @@ class Prefixer
      * @var array<string, ?ComposerPackage>
      */
     protected array $changedFiles = array();
+
+    protected ?Parser $parser = null;
+
+    protected ?NodeFinder $nodeFinder = null;
 
     public function __construct(
         PrefixerConfigInterface $config,
@@ -68,6 +73,8 @@ class Prefixer
      */
     public function replaceInFiles(DiscoveredSymbols $discoveredSymbols, array $files): void
     {
+        $replacementContext = $this->buildReplacementContext($discoveredSymbols);
+
         foreach ($files as $file) {
             if (!$this->config->isTargetDirectoryVendor()
                 && !$file->isDoCopy()
@@ -98,7 +105,7 @@ class Prefixer
              */
             $contents = $this->filesystem->read($file->getAbsoluteTargetPath());
 
-            $updatedContents = $this->replaceInString($discoveredSymbols, $contents);
+            $updatedContents = $this->replaceInStringWithContext($contents, $replacementContext);
 
             if ($updatedContents !== $contents) {
                 // TODO: diff here and debug log.
@@ -120,6 +127,7 @@ class Prefixer
      */
     public function replaceInProjectFiles(DiscoveredSymbols $discoveredSymbols, array $absoluteFilePathsArray): void
     {
+        $replacementContext = $this->buildReplacementContext($discoveredSymbols);
 
         foreach ($absoluteFilePathsArray as $fileAbsolutePath) {
             $relativeFilePath = $this->filesystem->getRelativePath(dirname($this->config->getAbsoluteTargetDirectory()), $fileAbsolutePath);
@@ -139,7 +147,7 @@ class Prefixer
             // Throws an exception, but unlikely to happen.
             $contents = $this->filesystem->read($fileAbsolutePath);
 
-            $updatedContents = $this->replaceInString($discoveredSymbols, $contents);
+            $updatedContents = $this->replaceInStringWithContext($contents, $replacementContext);
 
             if ($updatedContents !== $contents) {
                 $this->changedFiles[$fileAbsolutePath] = null;
@@ -159,69 +167,44 @@ class Prefixer
      */
     public function replaceInString(DiscoveredSymbols $discoveredSymbols, string $contents): string
     {
-        $classmapPrefix = $this->config->getClassmapPrefix();
-
-        $namespacesChanges = $discoveredSymbols->getDiscoveredNamespaceChanges($this->config->getNamespacePrefix());
-        $constants = $discoveredSymbols->getDiscoveredConstantChanges($this->config->getConstantsPrefix());
-        $classes = $discoveredSymbols->getGlobalClassChanges();
-        $functions = $discoveredSymbols->getDiscoveredFunctionChanges();
-
-        $contents = $this->prepareRelativeNamespaces($contents, $namespacesChanges);
-
-        if ($classmapPrefix) {
-            foreach ($classes as $classSymbol) {
-                $contents = $this->replaceClassname($contents, $classSymbol->getOriginalSymbolStripPrefix($classmapPrefix), $classmapPrefix);
-            }
-        }
-
-        // TODO: Move this out of the loop.
-        $namespacesChangesStrings = [];
-        foreach ($namespacesChanges as $originalNamespace => $namespaceSymbol) {
-            if (in_array($originalNamespace, $this->config->getExcludeNamespacesFromPrefixing())) {
-                $this->logger->info("Skipping namespace: $originalNamespace");
-                continue;
-            }
-            $namespacesChangesStrings[$originalNamespace] = $namespaceSymbol->getReplacement();
-        }
-        // This matters... it shouldn't.
-        uksort($namespacesChangesStrings, new NamespaceSort(NamespaceSort::SHORTEST));
-        foreach ($namespacesChangesStrings as $originalNamespace => $replacementNamespace) {
-            $contents = $this->replaceNamespace($contents, $originalNamespace, $replacementNamespace);
-        }
-
-        if (!is_null($this->config->getConstantsPrefix())) {
-            $contents = $this->replaceConstants($contents, $constants, $this->config->getConstantsPrefix());
-        }
-
-        foreach ($functions as $functionSymbol) {
-            $contents = $this->replaceFunctions($contents, $functionSymbol);
-        }
-
-        $contents = $this->replaceConstFetchNamespaces($discoveredSymbols, $contents);
-
-        return $contents;
+        return $this->replaceInStringWithContext(
+            $contents,
+            $this->buildReplacementContext($discoveredSymbols)
+        );
     }
 
     protected function replaceConstFetchNamespaces(DiscoveredSymbols $symbols, string $contents): string
     {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        return $this->replaceConstFetchNamespacesByMap(
+            $symbols->getDiscoveredNamespaces($this->config->getNamespacePrefix()),
+            $contents
+        );
+    }
+
+    /**
+     * @param array<string, NamespaceSymbol> $namespaceSymbols
+     */
+    protected function replaceConstFetchNamespacesByMap(array $namespaceSymbols, string $contents): string
+    {
+        if (empty($namespaceSymbols)) {
+            return $contents;
+        }
+
+        if (strpos($contents, '\\') === false) {
+            return $contents;
+        }
+
         try {
-            $ast = $parser->parse($contents);
+            $ast = $this->getParser()->parse($contents) ?? [];
         } catch (\PhpParser\Error $e) {
             $this->logger->warning("Skipping ::replaceConstFetchNamespaces() in file due to parse error: " . $e->getMessage());
             return $contents;
         }
 
-        $namespaceSymbols = $symbols->getDiscoveredNamespaces($this->config->getNamespacePrefix());
-        if (empty($namespaceSymbols)) {
-            return $contents;
-        }
-
-        $nodeFinder = new NodeFinder();
         $positions = [];
 
         /** @var ConstFetch[] $constFetches */
-        $constFetches = $nodeFinder->find($ast, function (Node $node) {
+        $constFetches = $this->getNodeFinder()->find($ast, function (Node $node) {
             return $node instanceof ConstFetch
                 && $node->name instanceof Name\FullyQualified;
         });
@@ -251,6 +234,149 @@ class Prefixer
         }
 
         return $contents;
+    }
+
+    /**
+     * @return array{
+     *     classmapPrefix:?string,
+     *     classes:array<string,ClassSymbol>,
+     *     namespaceChanges:array<string,NamespaceSymbol>,
+     *     namespaceChangesStrings:array<string,string>,
+     *     constantsPrefix:?string,
+     *     constants:array<string>,
+     *     functionReplacements:array<string,string>,
+     *     namespaceSymbols:array<string,NamespaceSymbol>
+     * }
+     */
+    protected function buildReplacementContext(DiscoveredSymbols $discoveredSymbols): array
+    {
+        $namespaceChanges = $discoveredSymbols->getDiscoveredNamespaceChanges($this->config->getNamespacePrefix());
+        $constantsPrefix = $this->config->getConstantsPrefix();
+
+        return [
+            'classmapPrefix' => $this->config->getClassmapPrefix(),
+            'classes' => $discoveredSymbols->getGlobalClassChanges(),
+            'namespaceChanges' => $namespaceChanges,
+            'namespaceChangesStrings' => $this->buildNamespaceReplacementMap($namespaceChanges),
+            'constantsPrefix' => $constantsPrefix,
+            'constants' => $discoveredSymbols->getDiscoveredConstantChanges($constantsPrefix),
+            'functionReplacements' => $this->buildFunctionReplacementMap($discoveredSymbols->getDiscoveredFunctionChanges()),
+            'namespaceSymbols' => $discoveredSymbols->getDiscoveredNamespaces($this->config->getNamespacePrefix()),
+        ];
+    }
+
+    /**
+     * @param array<string, NamespaceSymbol> $namespaceChanges
+     * @return array<string,string>
+     */
+    protected function buildNamespaceReplacementMap(array $namespaceChanges): array
+    {
+        $namespaceChangesStrings = [];
+        foreach ($namespaceChanges as $originalNamespace => $namespaceSymbol) {
+            if (in_array($originalNamespace, $this->config->getExcludeNamespacesFromPrefixing(), true)) {
+                $this->logger->info("Skipping namespace: $originalNamespace");
+                continue;
+            }
+            $namespaceChangesStrings[$originalNamespace] = $namespaceSymbol->getReplacement();
+        }
+
+        // This matters... it shouldn't.
+        uksort($namespaceChangesStrings, new NamespaceSort(NamespaceSort::SHORTEST));
+
+        return $namespaceChangesStrings;
+    }
+
+    /**
+     * @param FunctionSymbol[] $functions
+     * @return array<string,string>
+     */
+    protected function buildFunctionReplacementMap(array $functions): array
+    {
+        $orderedFunctionReplacements = [];
+        foreach ($functions as $functionSymbol) {
+            $originalFunctionString = $functionSymbol->getOriginalSymbol();
+            $replacementFunctionString = $functionSymbol->getReplacement();
+            if ($originalFunctionString === $replacementFunctionString) {
+                continue;
+            }
+            $orderedFunctionReplacements[] = [
+                'original' => $originalFunctionString,
+                'replacement' => $replacementFunctionString,
+            ];
+        }
+
+        $functionReplacementMap = [];
+        $replacementsCount = count($orderedFunctionReplacements);
+
+        for ($i = 0; $i < $replacementsCount; $i++) {
+            $replacementFunctionString = $orderedFunctionReplacements[$i]['replacement'];
+
+            // Preserve legacy behavior where replacements can cascade through later symbols.
+            for ($j = $i + 1; $j < $replacementsCount; $j++) {
+                if ($replacementFunctionString === $orderedFunctionReplacements[$j]['original']) {
+                    $replacementFunctionString = $orderedFunctionReplacements[$j]['replacement'];
+                }
+            }
+
+            $functionReplacementMap[$orderedFunctionReplacements[$i]['original']] = $replacementFunctionString;
+        }
+
+        return $functionReplacementMap;
+    }
+
+    /**
+     * @param array{
+     *     classmapPrefix:?string,
+     *     classes:array<string,ClassSymbol>,
+     *     namespaceChanges:array<string,NamespaceSymbol>,
+     *     namespaceChangesStrings:array<string,string>,
+     *     constantsPrefix:?string,
+     *     constants:array<string>,
+     *     functionReplacements:array<string,string>,
+     *     namespaceSymbols:array<string,NamespaceSymbol>
+     * } $replacementContext
+     *
+     * @throws Exception
+     */
+    protected function replaceInStringWithContext(string $contents, array $replacementContext): string
+    {
+        $contents = $this->prepareRelativeNamespaces($contents, $replacementContext['namespaceChanges']);
+
+        if (!empty($replacementContext['classmapPrefix'])) {
+            foreach ($replacementContext['classes'] as $classSymbol) {
+                $contents = $this->replaceClassname(
+                    $contents,
+                    $classSymbol->getOriginalSymbolStripPrefix($replacementContext['classmapPrefix']),
+                    $replacementContext['classmapPrefix']
+                );
+            }
+        }
+
+        foreach ($replacementContext['namespaceChangesStrings'] as $originalNamespace => $replacementNamespace) {
+            $escapedNamespace = str_replace('\\', '\\\\', $originalNamespace);
+            if (strpos($contents, $originalNamespace) === false
+                && strpos($contents, '\\' . $originalNamespace) === false
+                && strpos($contents, $escapedNamespace) === false
+                && strpos($contents, '\\\\' . $escapedNamespace) === false
+            ) {
+                continue;
+            }
+            $contents = $this->replaceNamespace($contents, $originalNamespace, $replacementNamespace);
+        }
+
+        if (!is_null($replacementContext['constantsPrefix'])) {
+            $contents = $this->replaceConstants(
+                $contents,
+                $replacementContext['constants'],
+                $replacementContext['constantsPrefix']
+            );
+        }
+
+        if (!empty($replacementContext['functionReplacements'])) {
+            $contents = $this->replaceFunctionsBatch($contents, $replacementContext['functionReplacements']);
+        }
+
+        return $this->replaceConstFetchNamespacesByMap($replacementContext['namespaceSymbols'], $contents);
     }
 
     /**
@@ -501,17 +627,25 @@ class Prefixer
 
     protected function replaceFunctions(string $contents, FunctionSymbol $functionSymbol): string
     {
-        $originalFunctionString = $functionSymbol->getOriginalSymbol();
-        $replacementFunctionString = $functionSymbol->getReplacement();
+        return $this->replaceFunctionsBatch(
+            $contents,
+            [
+                $functionSymbol->getOriginalSymbol() => $functionSymbol->getReplacement(),
+            ]
+        );
+    }
 
-        if ($originalFunctionString === $replacementFunctionString) {
+    /**
+     * @param array<string,string> $functionReplacementMap
+     */
+    protected function replaceFunctionsBatch(string $contents, array $functionReplacementMap): string
+    {
+        if (empty($functionReplacementMap)) {
             return $contents;
         }
 
-        $nodeFinder = new NodeFinder();
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
         try {
-            $ast = $parser->parse($contents);
+            $ast = $this->getParser()->parse($contents) ?? [];
         } catch (\PhpParser\Error $e) {
             $this->logger->warning("Skipping ::replaceFunctions() in file due to parse error: " . $e->getMessage());
             return $contents;
@@ -520,53 +654,69 @@ class Prefixer
         $positions = [];
 
         // Function declarations (global only)
-        $functionDefs = $nodeFinder->findInstanceOf($ast, Function_::class);
+        $functionDefs = $this->getNodeFinder()->findInstanceOf($ast, Function_::class);
         foreach ($functionDefs as $func) {
-            if ($func->name->name === $originalFunctionString) {
-                $positions[] = [
-                    'start' => $func->name->getStartFilePos(),
-                    'end' => $func->name->getEndFilePos() + 1,
-                ];
+            $functionName = $func->name->name;
+            if (!isset($functionReplacementMap[$functionName])) {
+                continue;
             }
+            $positions[] = [
+                'start' => $func->name->getStartFilePos(),
+                'end' => $func->name->getEndFilePos() + 1,
+                'replacement' => $functionReplacementMap[$functionName],
+            ];
         }
 
         // Calls (global only)
-        $calls = $nodeFinder->findInstanceOf($ast, FuncCall::class);
+        $calls = $this->getNodeFinder()->findInstanceOf($ast, FuncCall::class);
         foreach ($calls as $call) {
-            if ($call->name instanceof Name &&
-                $call->name->toString() === $originalFunctionString
-            ) {
-                $positions[] = [
-                    'start' => $call->name->getStartFilePos(),
-                    'end' => $call->name->getEndFilePos() + 1,
-                ];
+            if (!($call->name instanceof Name)) {
+                continue;
             }
+
+            $functionName = $call->name->toString();
+            if (!isset($functionReplacementMap[$functionName])) {
+                continue;
+            }
+
+            $positions[] = [
+                'start' => $call->name->getStartFilePos(),
+                'end' => $call->name->getEndFilePos() + 1,
+                'replacement' => $functionReplacementMap[$functionName],
+            ];
         }
 
         $functionsUsingCallable = [
-            'function_exists',
-            'call_user_func',
-            'call_user_func_array',
-            'forward_static_call',
-            'forward_static_call_array',
-            'register_shutdown_function',
-            'register_tick_function',
-            'unregister_tick_function',
+            'function_exists' => true,
+            'call_user_func' => true,
+            'call_user_func_array' => true,
+            'forward_static_call' => true,
+            'forward_static_call_array' => true,
+            'register_shutdown_function' => true,
+            'register_tick_function' => true,
+            'unregister_tick_function' => true,
         ];
 
         foreach ($calls as $call) {
-            if ($call->name instanceof Name &&
-                in_array($call->name->toString(), $functionsUsingCallable)
-                && isset($call->args[0])
-                && $call->args[0] instanceof Arg
-                && $call->args[0]->value instanceof String_
-                && $call->args[0]->value->value === $originalFunctionString
+            if (!($call->name instanceof Name)
+                || !isset($functionsUsingCallable[$call->name->toString()])
+                || !isset($call->args[0])
+                || !($call->args[0] instanceof Arg)
+                || !($call->args[0]->value instanceof String_)
             ) {
-                $positions[] = [
-                    'start' => $call->args[0]->value->getStartFilePos() + 1, // do not change quotes
-                    'end' => $call->args[0]->value->getEndFilePos(),
-                ];
+                continue;
             }
+
+            $functionName = $call->args[0]->value->value;
+            if (!isset($functionReplacementMap[$functionName])) {
+                continue;
+            }
+
+            $positions[] = [
+                'start' => $call->args[0]->value->getStartFilePos() + 1, // do not change quotes
+                'end' => $call->args[0]->value->getEndFilePos(),
+                'replacement' => $functionReplacementMap[$functionName],
+            ];
         }
 
         if (empty($positions)) {
@@ -577,7 +727,7 @@ class Prefixer
         usort($positions, fn($a, $b) => $b['start'] <=> $a['start']);
 
         foreach ($positions as $pos) {
-            $contents = substr_replace($contents, $replacementFunctionString, $pos['start'], $pos['end'] - $pos['start']);
+            $contents = substr_replace($contents, $pos['replacement'], $pos['start'], $pos['end'] - $pos['start']);
         }
         return $contents;
     }
@@ -606,10 +756,16 @@ class Prefixer
      */
     protected function prepareRelativeNamespaces(string $phpFileContent, array $discoveredNamespaceSymbols): string
     {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        if (empty($discoveredNamespaceSymbols)) {
+            return $phpFileContent;
+        }
+
+        if (strpos($phpFileContent, '\\') === false) {
+            return $phpFileContent;
+        }
 
         try {
-            $ast = $parser->parse($phpFileContent);
+            $ast = $this->getParser()->parse($phpFileContent) ?? [];
         } catch (\PhpParser\Error $e) {
             $this->logger->warning("Skipping ::prepareRelativeNamespaces() in file due to parse error: " . $e->getMessage());
             return $phpFileContent;
@@ -647,7 +803,9 @@ class Prefixer
             {
 
                 if ($node instanceof \PhpParser\Node\Stmt\Namespace_) {
-                    $this->using[] = $node->name->name;
+                    if (!is_null($node->name)) {
+                        $this->using[] = $node->name->name;
+                    }
                     $this->lastNode = $node;
                     return $node;
                 }
@@ -808,5 +966,23 @@ class Prefixer
         $updatedContent = str_replace('use \\\\', 'use \\', $updatedContent);
 
         return $updatedContent;
+    }
+
+    protected function getParser(): Parser
+    {
+        if (!isset($this->parser)) {
+            $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+        }
+
+        return $this->parser;
+    }
+
+    protected function getNodeFinder(): NodeFinder
+    {
+        if (!isset($this->nodeFinder)) {
+            $this->nodeFinder = new NodeFinder();
+        }
+
+        return $this->nodeFinder;
     }
 }

--- a/tests/Integration/ScanningParityFeatureTest.php
+++ b/tests/Integration/ScanningParityFeatureTest.php
@@ -23,6 +23,7 @@ class ScanningParityFeatureTest extends IntegrationTestCase
       "LocalScan\\": "src/"
     },
     "files": [
+      "src/plain-global.php",
       "src/globals.php",
       "src/multi.php"
     ]
@@ -47,6 +48,13 @@ namespace {
     }
 
     const GLOBAL_CONST = 'global';
+}
+PHP;
+
+        $plainGlobalPhp = <<<'PHP'
+<?php
+function plain_global_helper() {
+    return 'plain';
 }
 PHP;
 
@@ -115,6 +123,7 @@ JSON;
         mkdir($this->testsWorkingDir . '/scan-fixture/src', 0777, true);
         $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/composer.json', $dependencyComposerJson);
         $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/NamedClass.php', $namedPhp);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/plain-global.php', $plainGlobalPhp);
         $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/globals.php', $globalsPhp);
         $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/Consumer.php', $consumerPhp);
         $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/multi.php', $multiPhp);
@@ -130,22 +139,27 @@ JSON;
         $this->assertEquals(0, $exitCode, $output);
 
         $namedPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/NamedClass.php';
+        $plainGlobalPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/plain-global.php';
         $globalsPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/globals.php';
         $consumerPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/Consumer.php';
         $multiPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/multi.php';
 
         $this->assertTrue($this->getFileSystem()->fileExists($namedPath));
+        $this->assertTrue($this->getFileSystem()->fileExists($plainGlobalPath));
         $this->assertTrue($this->getFileSystem()->fileExists($globalsPath));
         $this->assertTrue($this->getFileSystem()->fileExists($consumerPath));
         $this->assertTrue($this->getFileSystem()->fileExists($multiPath));
 
         $namedOutput = $this->getFileSystem()->read($namedPath);
+        $plainGlobalOutput = $this->getFileSystem()->read($plainGlobalPath);
         $globalsOutput = $this->getFileSystem()->read($globalsPath);
         $consumerOutput = $this->getFileSystem()->read($consumerPath);
         $multiOutput = $this->getFileSystem()->read($multiPath);
 
         $this->assertSame(['MyPrefix\\LocalScan'], $this->getNamespaces($namedOutput));
         $this->assertContains('NamedClass', $this->getClassNames($namedOutput));
+
+        $this->assertContains('myprefix_plain_global_helper', $this->getFunctionDeclarationNames($plainGlobalOutput));
 
         $this->assertContains('MyPrefix_GlobalClass', $this->getClassNames($globalsOutput));
         $this->assertContains('myprefix_global_helper', $this->getFunctionDeclarationNames($globalsOutput));

--- a/tests/Integration/ScanningParityFeatureTest.php
+++ b/tests/Integration/ScanningParityFeatureTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Tests\Integration;
+
+use BrianHenryIE\Strauss\IntegrationTestCase;
+use BrianHenryIE\Strauss\Tests\PhpAstAssertions;
+
+/**
+ * @coversNothing
+ */
+class ScanningParityFeatureTest extends IntegrationTestCase
+{
+    use PhpAstAssertions;
+
+    public function test_scanning_changes_do_not_change_transformed_output(): void
+    {
+        $dependencyComposerJson = <<<'JSON'
+{
+  "name": "local/scan-fixture",
+  "version": "1.0.0",
+  "autoload": {
+    "psr-4": {
+      "LocalScan\\": "src/"
+    },
+    "files": [
+      "src/globals.php",
+      "src/multi.php"
+    ]
+  }
+}
+JSON;
+
+        $namedPhp = <<<'PHP'
+<?php
+namespace LocalScan;
+
+class NamedClass {}
+PHP;
+
+        $globalsPhp = <<<'PHP'
+<?php
+namespace {
+    class GlobalClass {}
+
+    function global_helper() {
+        return 'ok';
+    }
+
+    const GLOBAL_CONST = 'global';
+}
+PHP;
+
+        $consumerPhp = <<<'PHP'
+<?php
+namespace LocalScan;
+
+class Consumer {
+    public function run(): array {
+        $class = new \GlobalClass();
+        $value = \global_helper();
+        $const = \GLOBAL_CONST;
+        return [$class::class, $value, $const];
+    }
+}
+PHP;
+
+        $multiPhp = <<<'PHP'
+<?php
+namespace LocalScan\PartA {
+    class Alpha {}
+}
+
+namespace {
+    function shared_helper() {
+        return true;
+    }
+}
+
+namespace LocalScan\PartB {
+    class Beta {}
+}
+PHP;
+
+        $projectComposerJson = <<<'JSON'
+{
+  "name": "local/scanning-parity-project",
+  "version": "1.0.0",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../scan-fixture",
+      "options": {
+        "symlink": false
+      }
+    }
+  ],
+  "require": {
+    "local/scan-fixture": "*"
+  },
+  "extra": {
+    "strauss": {
+      "namespace_prefix": "MyPrefix\\",
+      "classmap_prefix": "MyPrefix_",
+      "functions_prefix": "myprefix_",
+      "constants_prefix": "MYPREFIX_",
+      "target_directory": "vendor-prefixed",
+      "classmap_output": false
+    }
+  }
+}
+JSON;
+
+        mkdir($this->testsWorkingDir . '/scan-fixture/src', 0777, true);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/composer.json', $dependencyComposerJson);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/NamedClass.php', $namedPhp);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/globals.php', $globalsPhp);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/Consumer.php', $consumerPhp);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/scan-fixture/src/multi.php', $multiPhp);
+
+        mkdir($this->testsWorkingDir . '/project', 0777, true);
+        $this->getFileSystem()->write($this->testsWorkingDir . '/project/composer.json', $projectComposerJson);
+
+        chdir($this->testsWorkingDir . '/project');
+        exec('composer install --no-interaction --no-progress --no-ansi --quiet', $composerInstallOutput, $composerInstallExitCode);
+        $this->assertEquals(0, $composerInstallExitCode, implode(PHP_EOL, $composerInstallOutput));
+
+        $exitCode = $this->runStrauss($output);
+        $this->assertEquals(0, $exitCode, $output);
+
+        $namedPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/NamedClass.php';
+        $globalsPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/globals.php';
+        $consumerPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/Consumer.php';
+        $multiPath = $this->testsWorkingDir . '/project/vendor-prefixed/local/scan-fixture/src/multi.php';
+
+        $this->assertTrue($this->getFileSystem()->fileExists($namedPath));
+        $this->assertTrue($this->getFileSystem()->fileExists($globalsPath));
+        $this->assertTrue($this->getFileSystem()->fileExists($consumerPath));
+        $this->assertTrue($this->getFileSystem()->fileExists($multiPath));
+
+        $namedOutput = $this->getFileSystem()->read($namedPath);
+        $globalsOutput = $this->getFileSystem()->read($globalsPath);
+        $consumerOutput = $this->getFileSystem()->read($consumerPath);
+        $multiOutput = $this->getFileSystem()->read($multiPath);
+
+        $this->assertSame(['MyPrefix\\LocalScan'], $this->getNamespaces($namedOutput));
+        $this->assertContains('NamedClass', $this->getClassNames($namedOutput));
+
+        $this->assertContains('MyPrefix_GlobalClass', $this->getClassNames($globalsOutput));
+        $this->assertContains('myprefix_global_helper', $this->getFunctionDeclarationNames($globalsOutput));
+        $this->assertContains('MYPREFIX_GLOBAL_CONST', $this->getConstantDeclarationNames($globalsOutput));
+
+        $this->assertSame(['MyPrefix\\LocalScan'], $this->getNamespaces($consumerOutput));
+        $this->assertContains('MyPrefix_GlobalClass', $this->getNewClassNames($consumerOutput));
+        $this->assertContains('myprefix_global_helper', $this->getFunctionCallNames($consumerOutput));
+        $this->assertContains('MYPREFIX_GLOBAL_CONST', $this->getConstFetchNames($consumerOutput));
+
+        $this->assertContains('MyPrefix\\LocalScan\\PartA', $this->getNamespaces($multiOutput));
+        $this->assertContains('MyPrefix\\LocalScan\\PartB', $this->getNamespaces($multiOutput));
+        $this->assertContains('myprefix_shared_helper', $this->getFunctionDeclarationNames($multiOutput));
+    }
+}

--- a/tests/PhpAstAssertions.php
+++ b/tests/PhpAstAssertions.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Tests;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+
+trait PhpAstAssertions
+{
+    /**
+     * @return Node[]
+     */
+    private function parsePhp(string $contents): array
+    {
+        return (new ParserFactory())->createForNewestSupportedVersion()->parse($contents) ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getNamespaces(string $contents): array
+    {
+        $namespaces = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), Namespace_::class);
+
+        return array_map(
+            static fn(Namespace_ $namespace): string => $namespace->name instanceof Name ? $namespace->name->toString() : '\\',
+            $namespaces
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getClassNames(string $contents): array
+    {
+        $classes = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), Class_::class);
+
+        return array_values(array_map(
+            static fn(Class_ $class): string => $class->name instanceof Node\Identifier ? $class->name->toString() : '',
+            array_filter($classes, static fn(Class_ $class): bool => $class->name instanceof Node\Identifier)
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getFunctionDeclarationNames(string $contents): array
+    {
+        $functions = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), Function_::class);
+
+        return array_map(
+            static fn(Function_ $function): string => $function->name->toString(),
+            $functions
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getConstantDeclarationNames(string $contents): array
+    {
+        $consts = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), Const_::class);
+        $names = [];
+        foreach ($consts as $const) {
+            foreach ($const->consts as $declaredConst) {
+                $names[] = $declaredConst->name->toString();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getNewClassNames(string $contents): array
+    {
+        $newExpressions = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), New_::class);
+
+        return array_values(array_map(
+            static fn(New_ $new): string => $new->class instanceof Name ? $new->class->toString() : '',
+            array_filter($newExpressions, static fn(New_ $new): bool => $new->class instanceof Name)
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getFunctionCallNames(string $contents): array
+    {
+        $calls = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), FuncCall::class);
+
+        return array_values(array_map(
+            static fn(FuncCall $call): string => $call->name instanceof Name ? $call->name->toString() : '',
+            array_filter($calls, static fn(FuncCall $call): bool => $call->name instanceof Name)
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getClassMethodNames(string $contents): array
+    {
+        $methods = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), ClassMethod::class);
+
+        return array_map(
+            static fn(ClassMethod $method): string => $method->name->toString(),
+            $methods
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getCallableStringValues(string $contents): array
+    {
+        $calls = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), FuncCall::class);
+        $callableStrings = [];
+        foreach ($calls as $call) {
+            if (!$call->name instanceof Name) {
+                continue;
+            }
+            if (!in_array($call->name->toString(), ['call_user_func', 'call_user_func_array', 'function_exists'], true)) {
+                continue;
+            }
+            $firstArgument = $call->args[0]->value ?? null;
+            if ($firstArgument instanceof String_) {
+                $callableStrings[] = $firstArgument->value;
+            }
+        }
+
+        return $callableStrings;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getConstFetchNames(string $contents): array
+    {
+        $constFetches = (new NodeFinder())->findInstanceOf($this->parsePhp($contents), ConstFetch::class);
+
+        return array_map(
+            static fn(ConstFetch $constFetch): string => $constFetch->name->toString(),
+            $constFetches
+        );
+    }
+}

--- a/tests/Unit/Composer/ComposerPackageFactoryParityTest.php
+++ b/tests/Unit/Composer/ComposerPackageFactoryParityTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Composer;
+
+use BrianHenryIE\Strauss\TestCase;
+use Composer\Factory;
+use Composer\IO\NullIO;
+use JsonException;
+
+/**
+ * @covers \BrianHenryIE\Strauss\Composer\ComposerPackage
+ */
+class ComposerPackageFactoryParityTest extends TestCase
+{
+    /**
+     * @return array<string, array{0:string}>
+     */
+    public static function fixtureProvider(): array
+    {
+        return [
+            'libmergepdf' => [__DIR__ . '/composerpackage-test-libmergepdf.json'],
+            'easypost' => [__DIR__ . '/composerpackage-test-easypost-php.json'],
+            'php-di' => [__DIR__ . '/composerpackage-test-php-di.json'],
+        ];
+    }
+
+    /**
+     * @dataProvider fixtureProvider
+     */
+    public function test_from_file_matches_legacy_factory_create(string $fixturePath): void
+    {
+        $legacyComposer = Factory::create(new NullIO(), $fixturePath, true);
+        $legacy = new ComposerPackage($legacyComposer);
+
+        $fast = ComposerPackage::fromFile($fixturePath);
+
+        self::assertSame(
+            $this->snapshotWithPaths($legacy),
+            $this->snapshotWithPaths($fast)
+        );
+    }
+
+    /**
+     * @dataProvider fixtureProvider
+     * @throws JsonException
+     */
+    public function test_from_composer_json_array_matches_full_load_behavior(string $fixturePath): void
+    {
+        $raw = file_get_contents($fixturePath);
+        self::assertIsString($raw);
+        $json = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+        $factory = new Factory();
+        $legacyComposer = $factory->createComposer(new NullIO(), $json, true, null, true);
+        $legacy = new ComposerPackage($legacyComposer);
+
+        $fast = ComposerPackage::fromComposerJsonArray($json);
+
+        self::assertSame(
+            $this->snapshotWithoutPaths($legacy),
+            $this->snapshotWithoutPaths($fast)
+        );
+    }
+
+    /**
+     * @param ComposerPackage $package
+     * @return array{
+     *     name:string,
+     *     autoload:array<string,mixed>,
+     *     requires:array<int,string>,
+     *     license:string,
+     *     relative_path:?string,
+     *     absolute_path:?string
+     * }
+     */
+    private function snapshotWithPaths(ComposerPackage $package): array
+    {
+        $requires = $package->getRequiresNames();
+        sort($requires);
+
+        return [
+            'name' => $package->getPackageName(),
+            'autoload' => $package->getAutoload(),
+            'requires' => array_values($requires),
+            'license' => $package->getLicense(),
+            'relative_path' => $package->getRelativePath(),
+            'absolute_path' => $package->getPackageAbsolutePath(),
+        ];
+    }
+
+    /**
+     * @param ComposerPackage $package
+     * @return array{
+     *     name:string,
+     *     autoload:array<string,mixed>,
+     *     requires:array<int,string>,
+     *     license:string
+     * }
+     */
+    private function snapshotWithoutPaths(ComposerPackage $package): array
+    {
+        $requires = $package->getRequiresNames();
+        sort($requires);
+
+        return [
+            'name' => $package->getPackageName(),
+            'autoload' => $package->getAutoload(),
+            'requires' => array_values($requires),
+            'license' => $package->getLicense(),
+        ];
+    }
+}

--- a/tests/Unit/Composer/ComposerPackagePlatformPackageTest.php
+++ b/tests/Unit/Composer/ComposerPackagePlatformPackageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Composer;
+
+use BrianHenryIE\Strauss\TestCase;
+
+/**
+ * @covers \BrianHenryIE\Strauss\Composer\ComposerPackage
+ */
+class ComposerPackagePlatformPackageTest extends TestCase
+{
+    public function test_get_requires_names_keeps_php_variants(): void
+    {
+        $composer = ComposerPackage::fromComposerJsonArray(
+            [
+                'name' => 'acme/test',
+                'type' => 'library',
+                'require' => [
+                    'php' => '^8.0',
+                    'php-64bit' => '*',
+                    'ext-json' => '*',
+                    'acme/dep' => '^1.0',
+                ],
+            ]
+        );
+
+        $requiresNames = $composer->getRequiresNames();
+
+        self::assertContains('php-64bit', $requiresNames);
+        self::assertContains('acme/dep', $requiresNames);
+        self::assertNotContains('php', $requiresNames);
+        self::assertNotContains('ext-json', $requiresNames);
+    }
+
+    /**
+     * @dataProvider platformPackageNameProvider
+     */
+    public function test_is_platform_package_name(string $packageName, bool $includePhpVariants, bool $expected): void
+    {
+        self::assertSame($expected, ComposerPackage::isPlatformPackageName($packageName, $includePhpVariants));
+    }
+
+    /**
+     * @return array<string,array{0:string,1:bool,2:bool}>
+     */
+    public static function platformPackageNameProvider(): array
+    {
+        return [
+            'php is platform' => ['php', false, true],
+            'extension is platform' => ['ext-json', false, true],
+            'php variant excluded by default' => ['php-64bit', false, false],
+            'php variant included when requested' => ['php-64bit', true, true],
+            'virtual package with slash is not platform' => ['php-http/client-implementation', true, false],
+            'vendor package is not platform' => ['acme/package', true, false],
+        ];
+    }
+}

--- a/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
+++ b/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Console\Commands;
+
+use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use BrianHenryIE\Strauss\TestCase;
+use Mockery;
+use Monolog\Logger;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @coversDefaultClass \BrianHenryIE\Strauss\Console\Commands\AbstractRenamespacerCommand
+ */
+class AbstractRenamespacerCommandTest extends TestCase
+{
+    /**
+     * @dataProvider provider_logger_processors_only_receive_visible_levels
+     *
+     * @param string[] $args
+     * @param string[] $expectedLevels
+     */
+    public function test_logger_processors_only_receive_visible_levels(array $args, array $expectedLevels): void
+    {
+        $processor = $this->runProbeCommand($args);
+
+        self::assertSame($expectedLevels, $processor->levels);
+    }
+
+    /**
+     * @return array<string,array{0:string[],1:string[]}>
+     */
+    public static function provider_logger_processors_only_receive_visible_levels(): array
+    {
+        return [
+            'default' => [[], ['NOTICE']],
+            'info' => [['--info'], ['INFO', 'NOTICE']],
+            'debug' => [['--debug'], ['DEBUG', 'INFO', 'NOTICE']],
+            'dry-run' => [['--dry-run'], ['DEBUG', 'INFO', 'NOTICE']],
+            'silent' => [['--silent'], []],
+        ];
+    }
+
+    /**
+     * @param string[] $args
+     */
+    private function runProbeCommand(array $args = []): CountingLogProcessor
+    {
+        $processor = new CountingLogProcessor();
+        $command = new LoggingProbeCommand($processor);
+        $input = new ArgvInput(array_merge(['probe'], $args));
+        $output = new BufferedOutput();
+
+        $exitCode = $command->run($input, $output);
+
+        self::assertSame(0, $exitCode);
+
+        return $processor;
+    }
+}
+
+class LoggingProbeCommand extends AbstractRenamespacerCommand
+{
+    public function __construct(private CountingLogProcessor $processor)
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('probe');
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var StraussConfig&\Mockery\MockInterface $config */
+        $config = Mockery::mock(StraussConfig::class);
+        $config->shouldReceive('isDryRun')->andReturn($input->hasOption('dry-run') && $input->getOption('dry-run') !== false);
+        $this->config = $config;
+
+        parent::execute($input, $output);
+
+        if ($this->logger instanceof Logger) {
+            $this->logger->pushProcessor($this->processor);
+        }
+
+        $this->logger->debug('debug record');
+        $this->logger->info('info record');
+        $this->logger->notice('notice record');
+
+        return self::SUCCESS;
+    }
+}
+
+class CountingLogProcessor
+{
+    /** @var string[] */
+    public array $levels = [];
+
+    /**
+     * @param array{level_name:string} $record
+     * @return array{level_name:string}
+     */
+    public function __invoke(array $record): array
+    {
+        $this->levels[] = $record['level_name'];
+
+        return $record;
+    }
+}

--- a/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
+++ b/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
@@ -63,8 +63,11 @@ class AbstractRenamespacerCommandTest extends TestCase
 
 class LoggingProbeCommand extends AbstractRenamespacerCommand
 {
-    public function __construct(private CountingLogProcessor $processor)
+    private CountingLogProcessor $processor;
+
+    public function __construct(CountingLogProcessor $processor)
     {
+        $this->processor = $processor;
         parent::__construct();
     }
 

--- a/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
+++ b/tests/Unit/Console/Commands/AbstractRenamespacerCommandTest.php
@@ -2,14 +2,9 @@
 
 namespace BrianHenryIE\Strauss\Console\Commands;
 
-use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
 use BrianHenryIE\Strauss\TestCase;
-use Mockery;
-use Monolog\Logger;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @coversDefaultClass \BrianHenryIE\Strauss\Console\Commands\AbstractRenamespacerCommand
@@ -24,9 +19,7 @@ class AbstractRenamespacerCommandTest extends TestCase
      */
     public function test_logger_processors_only_receive_visible_levels(array $args, array $expectedLevels): void
     {
-        $processor = $this->runProbeCommand($args);
-
-        self::assertSame($expectedLevels, $processor->levels);
+        self::assertSame($expectedLevels, $this->runProbeCommand($args));
     }
 
     /**
@@ -45,11 +38,11 @@ class AbstractRenamespacerCommandTest extends TestCase
 
     /**
      * @param string[] $args
+     * @return string[]
      */
-    private function runProbeCommand(array $args = []): CountingLogProcessor
+    private function runProbeCommand(array $args = []): array
     {
-        $processor = new CountingLogProcessor();
-        $command = new LoggingProbeCommand($processor);
+        $command = new LoggingProbeCommand();
         $input = new ArgvInput(array_merge(['probe'], $args));
         $output = new BufferedOutput();
 
@@ -57,60 +50,6 @@ class AbstractRenamespacerCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        return $processor;
-    }
-}
-
-class LoggingProbeCommand extends AbstractRenamespacerCommand
-{
-    private CountingLogProcessor $processor;
-
-    public function __construct(CountingLogProcessor $processor)
-    {
-        $this->processor = $processor;
-        parent::__construct();
-    }
-
-    protected function configure()
-    {
-        $this->setName('probe');
-        parent::configure();
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        /** @var StraussConfig&\Mockery\MockInterface $config */
-        $config = Mockery::mock(StraussConfig::class);
-        $config->shouldReceive('isDryRun')->andReturn($input->hasOption('dry-run') && $input->getOption('dry-run') !== false);
-        $this->config = $config;
-
-        parent::execute($input, $output);
-
-        if ($this->logger instanceof Logger) {
-            $this->logger->pushProcessor($this->processor);
-        }
-
-        $this->logger->debug('debug record');
-        $this->logger->info('info record');
-        $this->logger->notice('notice record');
-
-        return self::SUCCESS;
-    }
-}
-
-class CountingLogProcessor
-{
-    /** @var string[] */
-    public array $levels = [];
-
-    /**
-     * @param array{level_name:string} $record
-     * @return array{level_name:string}
-     */
-    public function __invoke(array $record): array
-    {
-        $this->levels[] = $record['level_name'];
-
-        return $record;
+        return $command->getProcessedLevels();
     }
 }

--- a/tests/Unit/Console/Commands/LoggingProbeCommand.php
+++ b/tests/Unit/Console/Commands/LoggingProbeCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Console\Commands;
+
+use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use Mockery;
+use Monolog\Logger;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LoggingProbeCommand extends AbstractRenamespacerCommand
+{
+    /** @var string[] */
+    private array $processedLevels = [];
+
+    protected function configure()
+    {
+        $this->setName('probe');
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->processedLevels = [];
+
+        /** @var StraussConfig&\Mockery\MockInterface $config */
+        $config = Mockery::mock(StraussConfig::class);
+        $config->shouldReceive('isDryRun')->andReturn($input->hasOption('dry-run') && $input->getOption('dry-run') !== false);
+        $this->config = $config;
+
+        parent::execute($input, $output);
+
+        if ($this->logger instanceof Logger) {
+            $this->logger->pushProcessor(function (array $record): array {
+                $this->processedLevels[] = $record['level_name'];
+
+                return $record;
+            });
+        }
+
+        $this->logger->debug('debug record');
+        $this->logger->info('info record');
+        $this->logger->notice('notice record');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getProcessedLevels(): array
+    {
+        return $this->processedLevels;
+    }
+}

--- a/tests/Unit/FileEnumeratorTest.php
+++ b/tests/Unit/FileEnumeratorTest.php
@@ -12,6 +12,7 @@ namespace BrianHenryIE\Strauss;
 
 use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Config\FileEnumeratorConfig;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
 use BrianHenryIE\Strauss\Pipeline\FileEnumerator;
 use Mockery;
 
@@ -45,5 +46,112 @@ class FileEnumeratorTest extends TestCase
         $this->assertEmpty($result->getFiles());
 
         $this->assertTrue($this->getTestLogger()->hasWarningRecords());
+    }
+
+    /**
+     * @covers ::compileFileListForDependencies
+     */
+    public function testCompileFileListForDependenciesAggregatesAndSortsFiles(): void
+    {
+        $config = Mockery::mock(FileEnumeratorConfig::class);
+        $config->allows('getAbsoluteVendorDirectory')->andReturn('/project/vendor/');
+        $config->allows('getAbsoluteTargetDirectory')->andReturn('/project/vendor-prefixed/');
+
+        $filesystem = Mockery::mock(FileSystem::class);
+        $filesystem->expects('findAllFilesAbsolutePaths')
+            ->with(['/project/vendor/vendor-b'])
+            ->andReturn(
+                [
+                    '/project/vendor/vendor-b/src/Z.php',
+                    '/project/vendor/vendor-b/src/B.php',
+                ]
+            );
+        $filesystem->expects('findAllFilesAbsolutePaths')
+            ->with(['/project/vendor/vendor-a'])
+            ->andReturn(['/project/vendor/vendor-a/src/A.php']);
+        $filesystem->allows('directoryExists')->andReturnFalse();
+        $filesystem->allows('fileExists')->andReturnTrue();
+        $filesystem->allows('getRelativePath')->andReturnArg(1);
+
+        $sut = new FileEnumerator($config, $filesystem, $this->getLogger());
+
+        $dependencyB = $this->mockDependency(
+            'vendor/vendor-b',
+            '/project/vendor/vendor-b',
+            'vendor/vendor-b/'
+        );
+        $dependencyA = $this->mockDependency(
+            'vendor/vendor-a',
+            '/project/vendor/vendor-a',
+            'vendor/vendor-a/'
+        );
+
+        $result = $sut->compileFileListForDependencies([$dependencyB, $dependencyA]);
+
+        $this->assertSame(
+            [
+                '/project/vendor/vendor-a/src/A.php',
+                '/project/vendor/vendor-b/src/B.php',
+                '/project/vendor/vendor-b/src/Z.php',
+            ],
+            array_keys($result->getFiles())
+        );
+    }
+
+    /**
+     * @covers ::compileFileListForDependencies
+     * @covers ::compileFileListForPaths
+     */
+    public function testCompileFileListForDependenciesMatchesPathsSourceSet(): void
+    {
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->createDirectory('mem://project/vendor/vendor-a/src');
+        $filesystem->write('mem://project/vendor/vendor-a/src/B.php', '<?php class BClass {}');
+        $filesystem->write('mem://project/vendor/vendor-a/src/A.php', '<?php class AClass {}');
+
+        $config = Mockery::mock(FileEnumeratorConfig::class);
+        $config->allows('getAbsoluteVendorDirectory')->andReturn('mem://project/vendor/');
+        $config->allows('getAbsoluteTargetDirectory')->andReturn('mem://project/vendor-prefixed/');
+
+        $dependencyForDependencies = $this->mockDependency(
+            'vendor/vendor-a',
+            'mem://project/vendor/vendor-a',
+            'vendor/vendor-a/'
+        );
+
+        $dependencyForPaths = $this->mockDependency(
+            'vendor/vendor-a',
+            'mem://project/vendor/vendor-a',
+            'vendor/vendor-a/'
+        );
+
+        $sutDependencies = new FileEnumerator($config, $filesystem, $this->getLogger());
+        $sutPaths = new FileEnumerator($config, $filesystem, $this->getLogger());
+
+        $dependenciesResult = $sutDependencies->compileFileListForDependencies([$dependencyForDependencies]);
+        $pathsResult = $sutPaths->compileFileListForPaths(
+            ['mem://project/vendor/vendor-a'],
+            $dependencyForPaths
+        );
+
+        $this->assertSame(
+            array_keys($dependenciesResult->getFiles()),
+            array_keys($pathsResult->getFiles())
+        );
+    }
+
+    private function mockDependency(
+        string $packageName,
+        string $absolutePath,
+        string $relativePath
+    ): ComposerPackage {
+        /** @var ComposerPackage&\Mockery\MockInterface $dependency */
+        $dependency = Mockery::mock(ComposerPackage::class);
+        $dependency->allows('getPackageName')->andReturn($packageName);
+        $dependency->allows('getPackageAbsolutePath')->andReturn($absolutePath);
+        $dependency->allows('getRelativePath')->andReturn($relativePath);
+        $dependency->allows('addFile');
+
+        return $dependency;
     }
 }

--- a/tests/Unit/Helpers/FileSystemTest.php
+++ b/tests/Unit/Helpers/FileSystemTest.php
@@ -113,6 +113,7 @@ class FileSystemTest extends TestCase
             $this->assertSame('C:/Users/dev/project/composer.json', $result);
         } else {
             $this->assertSame('C:\\Users\\dev\\project\\composer.json', $result);
+            $this->assertSame('C:\\Users\\dev\\project\\composer.json', $sut->makeAbsolute('C://Users/dev/project/composer.json'));
         }
     }
 
@@ -142,6 +143,21 @@ class FileSystemTest extends TestCase
         } else {
             $this->assertSame('d:\\Work\\project\\composer.json', $result);
         }
+    }
+
+    /**
+     * @covers ::makeAbsolute
+     */
+    public function testMakeAbsolutePreservesStreamWrapperProtocol(): void
+    {
+        $sut = $this->getInMemoryFileSystem();
+
+        $this->assertSame('mem://vendor/composer/installed.json', $sut->makeAbsolute('mem://vendor/composer/installed.json'));
+        $this->assertSame('mem://vendor/composer/installed.json', $sut->makeAbsolute('vendor/composer/installed.json'));
+        $this->assertSame(
+            DIRECTORY_SEPARATOR === '/' ? 'C:/Users/dev/project/composer.json' : 'C:\\Users\\dev\\project\\composer.json',
+            $sut->makeAbsolute('C://Users/dev/project/composer.json')
+        );
     }
 
     /**
@@ -195,6 +211,26 @@ class FileSystemTest extends TestCase
         $result = $sut->directoryExists(__FILE__);
 
         $this->assertFalse($result);
+    }
+
+    /**
+     * @covers ::isSymlinked
+     */
+    public function testIsSymlinkedReturnsFalseForNormalFileInWorkingDirectory(): void
+    {
+        $sut = new FileSystem(
+            new \League\Flysystem\Filesystem(
+                new LocalFilesystemAdapter(
+                    FileSystem::getFsRoot()
+                ),
+                [
+                    Config::OPTION_DIRECTORY_VISIBILITY => 'public',
+                ]
+            ),
+            __DIR__
+        );
+
+        $this->assertFalse($sut->isSymlinked(__FILE__));
     }
 
     /**

--- a/tests/Unit/Pipeline/Cleanup/CleanupTest.php
+++ b/tests/Unit/Pipeline/Cleanup/CleanupTest.php
@@ -78,7 +78,7 @@ class CleanupTest extends \BrianHenryIE\Strauss\TestCase
         }
 
         $sut = new Cleanup(
-            $this->cleanupConfig(deleteVendorFiles: true),
+            $this->cleanupConfig(true),
             $filesystem,
             new NullLogger()
         );
@@ -116,7 +116,7 @@ class CleanupTest extends \BrianHenryIE\Strauss\TestCase
         $excluded->shouldNotReceive('setDidDelete');
 
         $sut = new Cleanup(
-            $this->cleanupConfig(deleteVendorPackages: true, excludePackagesFromCopy: ['vendor-c/excluded']),
+            $this->cleanupConfig(false, true, ['vendor-c/excluded']),
             $filesystem,
             new NullLogger()
         );

--- a/tests/Unit/Pipeline/Cleanup/CleanupTest.php
+++ b/tests/Unit/Pipeline/Cleanup/CleanupTest.php
@@ -2,8 +2,11 @@
 
 namespace BrianHenryIE\Strauss\Pipeline\Cleanup;
 
+use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Config\CleanupConfigInterface;
 use BrianHenryIE\Strauss\Config\OptimizeAutoloaderConfigInterface;
+use BrianHenryIE\Strauss\Files\DiscoveredFiles;
+use BrianHenryIE\Strauss\Files\File;
 use Mockery;
 use Psr\Log\NullLogger;
 
@@ -46,5 +49,119 @@ class CleanupTest extends \BrianHenryIE\Strauss\TestCase
         };
 
         $this->assertFalse($sut->optimizeEnabledForTest());
+    }
+
+    public function test_delete_vendor_files_deletes_only_marked_files_and_prunes_empty_directories(): void
+    {
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->createDirectory('vendor/vendor-a/src');
+        $filesystem->createDirectory('vendor/vendor-a/empty');
+        $filesystem->createDirectory('vendor/vendor-a/nonempty');
+        $filesystem->write('vendor/vendor-a/src/DeleteMe.php', '<?php');
+        $filesystem->write('vendor/vendor-a/src/KeepMe.php', '<?php');
+        $filesystem->write('vendor/vendor-a/empty/DeleteMe.php', '<?php');
+        $filesystem->write('vendor/vendor-a/nonempty/DeleteMe.php', '<?php');
+        $filesystem->write('vendor/vendor-a/nonempty/KeepMe.php', '<?php');
+
+        $deleteFromSrc = new File('mem://vendor/vendor-a/src/DeleteMe.php', 'vendor-a/src/DeleteMe.php');
+        $deleteFromSrc->setDoDelete(true);
+        $keepInSrc = new File('mem://vendor/vendor-a/src/KeepMe.php', 'vendor-a/src/KeepMe.php');
+        $keepInSrc->setDoDelete(false);
+        $deleteFromEmpty = new File('mem://vendor/vendor-a/empty/DeleteMe.php', 'vendor-a/empty/DeleteMe.php');
+        $deleteFromEmpty->setDoDelete(true);
+        $deleteFromNonEmpty = new File('mem://vendor/vendor-a/nonempty/DeleteMe.php', 'vendor-a/nonempty/DeleteMe.php');
+        $deleteFromNonEmpty->setDoDelete(true);
+
+        $discoveredFiles = new DiscoveredFiles();
+        foreach ([$deleteFromSrc, $keepInSrc, $deleteFromEmpty, $deleteFromNonEmpty] as $file) {
+            $discoveredFiles->add($file);
+        }
+
+        $sut = new Cleanup(
+            $this->cleanupConfig(deleteVendorFiles: true),
+            $filesystem,
+            new NullLogger()
+        );
+
+        $sut->deleteFiles([], $discoveredFiles);
+
+        self::assertFalse($filesystem->fileExists('vendor/vendor-a/src/DeleteMe.php'));
+        self::assertTrue($filesystem->fileExists('vendor/vendor-a/src/KeepMe.php'));
+        self::assertFalse($filesystem->directoryExists('vendor/vendor-a/empty'));
+        self::assertTrue($filesystem->fileExists('vendor/vendor-a/nonempty/KeepMe.php'));
+        self::assertTrue($deleteFromSrc->getDidDelete());
+        self::assertFalse($keepInSrc->getDidDelete());
+        self::assertTrue($deleteFromEmpty->getDidDelete());
+        self::assertTrue($deleteFromNonEmpty->getDidDelete());
+    }
+
+    public function test_delete_vendor_packages_skips_excluded_packages_and_only_deletes_empty_parent_directories(): void
+    {
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->createDirectory('vendor/vendor-a/delete');
+        $filesystem->createDirectory('vendor/vendor-b/delete');
+        $filesystem->createDirectory('vendor/vendor-b/keep');
+        $filesystem->createDirectory('vendor/vendor-c/excluded');
+        $filesystem->write('vendor/vendor-a/delete/File.php', '<?php');
+        $filesystem->write('vendor/vendor-b/delete/File.php', '<?php');
+        $filesystem->write('vendor/vendor-b/keep/File.php', '<?php');
+        $filesystem->write('vendor/vendor-c/excluded/File.php', '<?php');
+
+        $deletedWithEmptyParent = $this->packageMock('vendor-a/delete', 'mem://vendor/vendor-a/delete');
+        $deletedWithNonEmptyParent = $this->packageMock('vendor-b/delete', 'mem://vendor/vendor-b/delete');
+        $excluded = $this->packageMock('vendor-c/excluded', 'mem://vendor/vendor-c/excluded');
+
+        $deletedWithEmptyParent->expects('setDidDelete')->once()->with(true);
+        $deletedWithNonEmptyParent->expects('setDidDelete')->once()->with(true);
+        $excluded->shouldNotReceive('setDidDelete');
+
+        $sut = new Cleanup(
+            $this->cleanupConfig(deleteVendorPackages: true, excludePackagesFromCopy: ['vendor-c/excluded']),
+            $filesystem,
+            new NullLogger()
+        );
+
+        $sut->deleteFiles(
+            [
+                'vendor-a/delete' => $deletedWithEmptyParent,
+                'vendor-b/delete' => $deletedWithNonEmptyParent,
+                'vendor-c/excluded' => $excluded,
+            ],
+            new DiscoveredFiles()
+        );
+
+        self::assertFalse($filesystem->directoryExists('vendor/vendor-a'));
+        self::assertFalse($filesystem->directoryExists('vendor/vendor-b/delete'));
+        self::assertTrue($filesystem->fileExists('vendor/vendor-b/keep/File.php'));
+        self::assertTrue($filesystem->fileExists('vendor/vendor-c/excluded/File.php'));
+    }
+
+    private function cleanupConfig(
+        bool $deleteVendorFiles = false,
+        bool $deleteVendorPackages = false,
+        array $excludePackagesFromCopy = []
+    ): CleanupConfigInterface {
+        $config = Mockery::mock(CleanupConfigInterface::class);
+        $config->shouldReceive('isDeleteVendorFiles')->andReturn($deleteVendorFiles);
+        $config->shouldReceive('isDeleteVendorPackages')->andReturn($deleteVendorPackages);
+        $config->shouldReceive('getAbsoluteVendorDirectory')->andReturn('mem://vendor');
+        $config->shouldReceive('getAbsoluteTargetDirectory')->andReturn('mem://vendor-prefixed');
+        $config->shouldReceive('getExcludePackagesFromCopy')->andReturn($excludePackagesFromCopy);
+
+        return $config;
+    }
+
+    /**
+     * @return ComposerPackage&\Mockery\MockInterface
+     */
+    private function packageMock(string $packageName, string $absolutePath): ComposerPackage
+    {
+        /** @var ComposerPackage&\Mockery\MockInterface $package */
+        $package = Mockery::mock(ComposerPackage::class);
+        $package->shouldReceive('getPackageName')->andReturn($packageName);
+        $package->shouldReceive('getPackageAbsolutePath')->andReturn($absolutePath);
+        $package->shouldReceive('getRelativePath')->andReturn($packageName);
+
+        return $package;
     }
 }

--- a/tests/Unit/Pipeline/Cleanup/InstalledJsonTest.php
+++ b/tests/Unit/Pipeline/Cleanup/InstalledJsonTest.php
@@ -411,12 +411,12 @@ EOD;
             $this->installedPackage('vendor/dev-only', ['psr-4' => ['Vendor\\DevOnly\\' => 'src/']]),
         ], true, ['vendor/dev-only']));
 
-        $config = $this->installedJsonConfig(excludePackagesFromCopy: ['vendor/excluded']);
+        $config = $this->installedJsonConfig(['vendor/excluded']);
         $sut = new InstalledJson($config, $fileSystem, new NullLogger());
 
         $flatDependencyTree = [
-            'vendor/copied' => $this->composerPackage(didCopy: true),
-            'vendor/excluded' => $this->composerPackage(didCopy: false),
+            'vendor/copied' => $this->composerPackage(true),
+            'vendor/excluded' => $this->composerPackage(false),
         ];
 
         $sut->copyInstalledJson();
@@ -452,7 +452,7 @@ EOD;
 
         $sut = new InstalledJson($this->installedJsonConfig(), $fileSystem, new NullLogger());
         $sut->cleanupVendorInstalledJson(
-            ['vendor/pkg' => $this->composerPackage(didDelete: false)],
+            ['vendor/pkg' => $this->composerPackage(false, false)],
             new DiscoveredSymbols()
         );
 
@@ -477,7 +477,7 @@ EOD;
 
         $sut = new InstalledJson($this->installedJsonConfig(), $fileSystem, new NullLogger());
         $sut->cleanupVendorInstalledJson(
-            ['vendor/pkg' => $this->composerPackage(didDelete: true)],
+            ['vendor/pkg' => $this->composerPackage(false, true)],
             new DiscoveredSymbols()
         );
 

--- a/tests/Unit/Pipeline/Cleanup/InstalledJsonTest.php
+++ b/tests/Unit/Pipeline/Cleanup/InstalledJsonTest.php
@@ -5,6 +5,7 @@ namespace BrianHenryIE\Strauss\Pipeline\Cleanup;
 use BrianHenryIE\Strauss\Composer\ComposerPackage;
 use BrianHenryIE\Strauss\Config\CleanupConfigInterface;
 use BrianHenryIE\Strauss\Files\FileWithDependency;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
 use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
 use BrianHenryIE\Strauss\Types\NamespaceSymbol;
 use Mockery;
@@ -399,6 +400,92 @@ EOD;
         $this->assertNotContains('psr/log', $targetInstalledPackageNames);
     }
 
+    public function test_clean_target_installed_json_keeps_copied_packages_and_removes_excluded_and_dev_packages(): void
+    {
+        $fileSystem = $this->getInMemoryFileSystem();
+        $fileSystem->createDirectory('vendor/composer');
+        $fileSystem->createDirectory('vendor-prefixed/vendor/copied/src');
+        $fileSystem->write('vendor/composer/installed.json', $this->installedJson([
+            $this->installedPackage('vendor/copied', ['psr-4' => ['Vendor\\Copied\\' => 'src/']]),
+            $this->installedPackage('vendor/excluded', ['psr-4' => ['Vendor\\Excluded\\' => 'src/']]),
+            $this->installedPackage('vendor/dev-only', ['psr-4' => ['Vendor\\DevOnly\\' => 'src/']]),
+        ], true, ['vendor/dev-only']));
+
+        $config = $this->installedJsonConfig(excludePackagesFromCopy: ['vendor/excluded']);
+        $sut = new InstalledJson($config, $fileSystem, new NullLogger());
+
+        $flatDependencyTree = [
+            'vendor/copied' => $this->composerPackage(didCopy: true),
+            'vendor/excluded' => $this->composerPackage(didCopy: false),
+        ];
+
+        $sut->copyInstalledJson();
+        $sut->cleanTargetDirInstalledJson($flatDependencyTree, new DiscoveredSymbols());
+
+        $targetInstalledJson = $this->readInstalledJsonArray($fileSystem, 'vendor-prefixed/composer/installed.json');
+        self::assertSame(['vendor/copied'], $this->packageNames($targetInstalledJson));
+        self::assertFalse($targetInstalledJson['dev']);
+        self::assertSame([], $targetInstalledJson['dev-package-names']);
+    }
+
+    public function test_cleanup_vendor_installed_json_filters_missing_autoload_paths_for_all_supported_autoload_types(): void
+    {
+        $fileSystem = $this->getInMemoryFileSystem();
+        $fileSystem->createDirectory('vendor/composer');
+        $fileSystem->write('vendor/vendor/pkg/src/keep.php', '<?php');
+        $fileSystem->createDirectory('vendor/vendor/pkg/classes');
+        $fileSystem->createDirectory('vendor/vendor/pkg/legacy');
+        $fileSystem->write('vendor/composer/installed.json', $this->installedJson([
+            $this->installedPackage('vendor/pkg', [
+                'files' => ['src/keep.php', 'src/missing.php'],
+                'classmap' => ['classes', 'missing-classmap'],
+                'psr-4' => [
+                    'Vendor\\Pkg\\' => 'src/',
+                    'Vendor\\Pkg\\Extra\\' => ['src/', 'missing-dir'],
+                ],
+                'psr-0' => [
+                    'Legacy_' => ['legacy', 'missing-legacy'],
+                ],
+                'exclude-from-classmap' => ['/Tests/'],
+            ]),
+        ]));
+
+        $sut = new InstalledJson($this->installedJsonConfig(), $fileSystem, new NullLogger());
+        $sut->cleanupVendorInstalledJson(
+            ['vendor/pkg' => $this->composerPackage(didDelete: false)],
+            new DiscoveredSymbols()
+        );
+
+        $installedJson = $this->readInstalledJsonArray($fileSystem, 'vendor/composer/installed.json');
+        $autoload = $installedJson['packages'][0]['autoload'];
+        self::assertSame(['src/keep.php'], $autoload['files']);
+        self::assertSame(['classes'], $autoload['classmap']);
+        self::assertSame('src/', $autoload['psr-4']['Vendor\\Pkg\\']);
+        self::assertSame(['src/'], $autoload['psr-4']['Vendor\\Pkg\\Extra\\']);
+        self::assertSame(['legacy'], $autoload['psr-0']['Legacy_']);
+        self::assertSame(['/Tests/'], $autoload['exclude-from-classmap']);
+    }
+
+    public function test_cleanup_vendor_installed_json_clears_deleted_package_autoload_when_package_record_remains(): void
+    {
+        $fileSystem = $this->getInMemoryFileSystem();
+        $fileSystem->createDirectory('vendor/composer');
+        $fileSystem->createDirectory('vendor/vendor/pkg/src');
+        $fileSystem->write('vendor/composer/installed.json', $this->installedJson([
+            $this->installedPackage('vendor/pkg', ['psr-4' => ['Vendor\\Pkg\\' => 'src/']]),
+        ]));
+
+        $sut = new InstalledJson($this->installedJsonConfig(), $fileSystem, new NullLogger());
+        $sut->cleanupVendorInstalledJson(
+            ['vendor/pkg' => $this->composerPackage(didDelete: true)],
+            new DiscoveredSymbols()
+        );
+
+        $installedJson = $this->readInstalledJsonArray($fileSystem, 'vendor/composer/installed.json');
+        self::assertSame(['vendor/pkg'], $this->packageNames($installedJson));
+        self::assertSame([], $installedJson['packages'][0]['autoload']);
+    }
+
     /**
      * @return string[]
      */
@@ -414,5 +501,79 @@ EOD;
             static fn(array $package): ?string => $package['name'] ?? null,
             $installedJsonArray['packages']
         )));
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $packages
+     * @param string[] $devPackageNames
+     */
+    private function installedJson(array $packages, bool $dev = false, array $devPackageNames = []): string
+    {
+        return json_encode([
+            'packages' => $packages,
+            'dev' => $dev,
+            'dev-package-names' => $devPackageNames,
+        ], JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * @param array<string,mixed> $autoload
+     * @return array<string,mixed>
+     */
+    private function installedPackage(string $name, array $autoload, ?string $installPath = null): array
+    {
+        return [
+            'name' => $name,
+            'version' => '1.0.0',
+            'version_normalized' => '1.0.0.0',
+            'type' => 'library',
+            'installation-source' => 'dist',
+            'autoload' => $autoload,
+            'install-path' => $installPath ?? '../' . $name,
+        ];
+    }
+
+    private function installedJsonConfig(array $excludePackagesFromCopy = []): CleanupConfigInterface
+    {
+        $config = Mockery::mock(CleanupConfigInterface::class);
+        $config->shouldReceive('getAbsoluteVendorDirectory')->andReturn('mem://vendor');
+        $config->shouldReceive('getAbsoluteTargetDirectory')->andReturn('mem://vendor-prefixed');
+        $config->shouldReceive('getExcludePackagesFromCopy')->andReturn($excludePackagesFromCopy);
+        $config->shouldReceive('isDryRun')->andReturnFalse();
+
+        return $config;
+    }
+
+    private function composerPackage(bool $didCopy = false, bool $didDelete = false): ComposerPackage
+    {
+        /** @var ComposerPackage|MockInterface $composerPackage */
+        $composerPackage = Mockery::mock(ComposerPackage::class);
+        $composerPackage->shouldReceive('didCopy')->andReturn($didCopy);
+        $composerPackage->shouldReceive('didDelete')->andReturn($didDelete);
+
+        return $composerPackage;
+    }
+
+    /**
+     * @return array{packages:array<int,array<string,mixed>>, dev:bool, dev-package-names:array<string>}
+     */
+    private function readInstalledJsonArray(FileSystem $fileSystem, string $path): array
+    {
+        $installedJson = json_decode($fileSystem->read($path), true);
+        self::assertIsArray($installedJson);
+
+        return $installedJson;
+    }
+
+    /**
+     * @param array{packages:array<int,array<string,mixed>>} $installedJson
+     * @return string[]
+     */
+    private function packageNames(array $installedJson): array
+    {
+        return array_values(array_map(
+            static fn(array $package): string => $package['name'],
+            $installedJson['packages']
+        ));
     }
 }

--- a/tests/Unit/Pipeline/DependenciesEnumeratorBehaviorTest.php
+++ b/tests/Unit/Pipeline/DependenciesEnumeratorBehaviorTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\Strauss\Composer\ComposerPackage;
+use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
+use BrianHenryIE\Strauss\TestCase;
+use Exception;
+use Psr\Log\NullLogger;
+
+/**
+ * @covers \BrianHenryIE\Strauss\Pipeline\DependenciesEnumerator
+ */
+class DependenciesEnumeratorBehaviorTest extends TestCase
+{
+    private string $cwdBeforeTest;
+
+    /** @var string[] */
+    private array $temporaryProjectDirs = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cwdBeforeTest = getcwd() ?: '';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->cwdBeforeTest !== '' && is_dir($this->cwdBeforeTest)) {
+            chdir($this->cwdBeforeTest);
+        }
+
+        foreach ($this->temporaryProjectDirs as $temporaryProjectDir) {
+            if ($this->getFileSystem()->directoryExists($temporaryProjectDir)) {
+                $this->getFileSystem()->deleteDirectory($temporaryProjectDir);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_discovers_transitive_dependencies_from_vendor_composer_files(): void
+    {
+        $projectDir = $this->createTempProjectDirectory();
+
+        $this->writeJsonFile($projectDir . '/composer.json', ['name' => 'local/project']);
+        $this->writeJsonFile($projectDir . '/composer.lock', ['packages' => []]);
+
+        $this->writeJsonFile($projectDir . '/vendor/acme/root/composer.json', [
+            'name' => 'acme/root',
+            'type' => 'library',
+            'require' => [
+                'acme/dep' => '^1.0',
+            ],
+            'autoload' => [
+                'psr-4' => ['Acme\\Root\\' => 'src/'],
+            ],
+        ]);
+
+        $this->writeJsonFile($projectDir . '/vendor/acme/dep/composer.json', [
+            'name' => 'acme/dep',
+            'type' => 'library',
+            'require' => (object) [],
+            'autoload' => [
+                'psr-4' => ['Acme\\Dep\\' => 'src/'],
+            ],
+        ]);
+
+        $dependencies = $this->runEnumerator($projectDir, ['acme/root']);
+
+        self::assertSame(['acme/root', 'acme/dep'], array_keys($dependencies));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_skips_package_when_provided_by_root_composer_json_and_vendor_file_missing(): void
+    {
+        $projectDir = $this->createTempProjectDirectory();
+
+        $this->writeJsonFile($projectDir . '/composer.json', [
+            'name' => 'local/project',
+            'provide' => ['virtual/provided' => '*'],
+        ]);
+        $this->writeJsonFile($projectDir . '/composer.lock', ['packages' => []]);
+
+        $dependencies = $this->runEnumerator($projectDir, ['virtual/provided']);
+
+        self::assertSame([], array_keys($dependencies));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_uses_composer_lock_fallback_when_vendor_composer_json_is_missing(): void
+    {
+        $projectDir = $this->createTempProjectDirectory();
+
+        $this->writeJsonFile($projectDir . '/composer.json', ['name' => 'local/project']);
+        $this->writeJsonFile($projectDir . '/composer.lock', [
+            'packages' => [
+                [
+                    'name' => 'missing/pkg',
+                    'type' => 'library',
+                    'require' => [
+                        'php' => '^8.0',
+                        'child/pkg' => '^1.0',
+                    ],
+                    'autoload' => [
+                        'psr-4' => ['Missing\\Pkg\\' => 'src/'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->writeJsonFile($projectDir . '/vendor/child/pkg/composer.json', [
+            'name' => 'child/pkg',
+            'type' => 'library',
+            'require' => (object) [],
+            'autoload' => [
+                'psr-4' => ['Child\\Pkg\\' => 'src/'],
+            ],
+        ]);
+
+        $dependencies = $this->runEnumerator($projectDir, ['missing/pkg']);
+
+        self::assertArrayHasKey('missing/pkg', $dependencies);
+        self::assertArrayHasKey('child/pkg', $dependencies);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_skips_non_metapackage_without_require_or_autoload_when_vendor_directory_missing(): void
+    {
+        $projectDir = $this->createTempProjectDirectory();
+
+        $this->writeJsonFile($projectDir . '/composer.json', ['name' => 'local/project']);
+        $this->writeJsonFile($projectDir . '/composer.lock', [
+            'packages' => [
+                [
+                    'name' => 'meta/like-package',
+                    'type' => 'library',
+                    'require' => [],
+                ],
+            ],
+        ]);
+
+        $dependencies = $this->runEnumerator($projectDir, ['meta/like-package']);
+
+        self::assertSame([], array_keys($dependencies));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_skips_virtual_and_platform_packages(): void
+    {
+        $projectDir = $this->createTempProjectDirectory();
+
+        $this->writeJsonFile($projectDir . '/composer.json', ['name' => 'local/project']);
+        $this->writeJsonFile($projectDir . '/composer.lock', ['packages' => []]);
+
+        $this->writeJsonFile($projectDir . '/vendor/acme/real/composer.json', [
+            'name' => 'acme/real',
+            'type' => 'library',
+            'require' => (object) [],
+            'autoload' => [
+                'psr-4' => ['Acme\\Real\\' => 'src/'],
+            ],
+        ]);
+
+        $dependencies = $this->runEnumerator(
+            $projectDir,
+            ['php', 'php-64bit', 'ext-json', 'php-http/client-implementation', 'acme/real']
+        );
+
+        self::assertSame(['acme/real'], array_keys($dependencies));
+    }
+
+    /**
+     * @param string $projectDir
+     * @param string[] $seedPackages
+     * @return array<string,ComposerPackage>
+     * @throws Exception
+     */
+    private function runEnumerator(string $projectDir, array $seedPackages): array
+    {
+        chdir($projectDir);
+
+        $config = new StraussConfig();
+        $config->setRelativeVendorDirectory('vendor');
+        $config->setPackages($seedPackages);
+
+        $enumerator = new DependenciesEnumerator($config, $this->newLocalFilesystem(), new NullLogger());
+
+        return $enumerator->getAllDependencies();
+    }
+
+    private function createTempProjectDirectory(): string
+    {
+        $projectDir = sys_get_temp_dir() . '/strauss-deps-enumerator-' . uniqid('', true);
+        mkdir($projectDir . '/vendor', 0777, true);
+        $projectDir = str_replace('\\', '/', $projectDir);
+        $this->temporaryProjectDirs[] = $projectDir;
+
+        return $projectDir;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function writeJsonFile(string $path, array $data): void
+    {
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents(
+            $path,
+            (string) json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+    }
+
+    private function newLocalFilesystem(): FileSystem
+    {
+        return $this->getNewFileSystem();
+    }
+}

--- a/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
+++ b/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
@@ -2,11 +2,8 @@
 
 namespace BrianHenryIE\Strauss\Pipeline;
 
-use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserContainer;
-use BrianHenryIE\SimplePhpParser\Parsers\PhpCodeParser;
 use BrianHenryIE\Strauss\Config\FileSymbolScannerConfigInterface;
 use BrianHenryIE\Strauss\Files\File;
-use BrianHenryIE\Strauss\Files\FileBase;
 use BrianHenryIE\Strauss\Helpers\FileSystem;
 use BrianHenryIE\Strauss\TestCase;
 use BrianHenryIE\Strauss\Types\ClassSymbol;
@@ -356,44 +353,5 @@ PHP,
             'interfaces' => $interfaces,
             'traits' => $traits,
         ];
-    }
-}
-
-class ScannerHarness extends FileSymbolScanner
-{
-    public function scanString(string $contents, FileBase $file): DiscoveredSymbols
-    {
-        $this->find($contents, $file, null);
-
-        return $this->discoveredSymbols;
-    }
-}
-
-final class LegacyGetFromStringScanner extends ScannerHarness
-{
-    protected function parsePhpCode(string $contents): ParserContainer
-    {
-        return PhpCodeParser::getFromString($contents);
-    }
-}
-
-final class RecordingParserInputScanner extends ScannerHarness
-{
-    /** @var string[] */
-    private array $parserInputs = [];
-
-    /**
-     * @return string[]
-     */
-    public function getParserInputs(): array
-    {
-        return $this->parserInputs;
-    }
-
-    protected function parsePhpCode(string $contents): ParserContainer
-    {
-        $this->parserInputs[] = $contents;
-
-        return parent::parsePhpCode($contents);
     }
 }

--- a/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
+++ b/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserContainer;
+use BrianHenryIE\SimplePhpParser\Parsers\PhpCodeParser;
+use BrianHenryIE\Strauss\Config\FileSymbolScannerConfigInterface;
+use BrianHenryIE\Strauss\Files\File;
+use BrianHenryIE\Strauss\Files\FileBase;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
+use BrianHenryIE\Strauss\TestCase;
+use BrianHenryIE\Strauss\Types\ClassSymbol;
+use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
+use BrianHenryIE\Strauss\Types\InterfaceSymbol;
+use BrianHenryIE\Strauss\Types\TraitSymbol;
+use Mockery;
+
+/**
+ * @covers \BrianHenryIE\Strauss\Pipeline\FileSymbolScanner
+ */
+class FileSymbolScannerParserParityTest extends TestCase
+{
+    public function test_process_parser_matches_legacy_for_single_namespace_symbol_data(): void
+    {
+        $contents = <<<'PHP'
+<?php
+namespace Example\Pkg;
+
+interface ParentContract {}
+interface ChildContract extends ParentContract {}
+
+abstract class BaseService implements ChildContract {}
+class ConcreteService extends BaseService {}
+
+trait LocalTrait {}
+
+function helper_fn() {
+    return true;
+}
+
+const LOCAL_CONST = 123;
+PHP;
+
+        $this->assertScannerParity($contents, '/tmp/single-namespace.php');
+    }
+
+    public function test_process_parser_matches_legacy_for_multi_namespace_symbol_data(): void
+    {
+        $contents = <<<'PHP'
+<?php
+namespace One\Ns {
+    interface InterfaceA {}
+    class ClassA implements InterfaceA {}
+}
+
+namespace {
+    class GlobalClass {}
+    function global_helper() {
+        return true;
+    }
+    const GLOBAL_CONST = 1;
+}
+
+namespace Two\Ns {
+    trait TraitB {}
+    class ClassB {}
+}
+PHP;
+
+        $this->assertScannerParity($contents, '/tmp/multi-namespace.php');
+    }
+
+    public function test_process_parser_matches_legacy_for_large_real_world_fixture(): void
+    {
+        $fixturePath = dirname(__DIR__, 2) . '/Issues/data/Mpdf.php';
+        $contents = file_get_contents($fixturePath);
+        self::assertIsString($contents);
+
+        $this->assertScannerParity($contents, '/tmp/mpdf.php');
+    }
+
+    /**
+     * @dataProvider edgeCaseProvider
+     */
+    public function test_process_parser_matches_legacy_for_edge_cases(string $contents, string $sourcePath): void
+    {
+        $this->assertScannerParity($contents, $sourcePath);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function edgeCaseProvider(): array
+    {
+        return [
+            'namespace_keyword_in_string_and_namespace_operator' => [
+                <<<'PHP'
+<?php
+namespace Edge\One;
+class Subject {}
+function inspect_namespace_operator() {
+    $txt = "namespace Edge\\Fake should not count";
+    return namespace\Subject::class . $txt;
+}
+PHP,
+                '/tmp/edge-ns-operator.php',
+            ],
+            'explicit_global_namespace_with_define_and_consts' => [
+                <<<'PHP'
+<?php
+namespace {
+    define('EDGE_DEFINED', 'ok');
+    const EDGE_CONST = 'c';
+    class GlobalEdge {
+        public const LOCAL = 'x';
+    }
+}
+PHP,
+                '/tmp/edge-global.php',
+            ],
+            'interface_inheritance_chain_and_implementation' => [
+                <<<'PHP'
+<?php
+namespace Edge\Two;
+interface A {}
+interface B extends A {}
+interface C extends B {}
+abstract class Core implements C {}
+class Child extends Core {}
+PHP,
+                '/tmp/edge-interfaces.php',
+            ],
+            'imports_aliases_and_use_statement_noise' => [
+                <<<'PHP'
+<?php
+namespace Edge\Three;
+use Vendor\Package\ExternalClass as ExternalAlias;
+class LocalOne {}
+class LocalTwo extends LocalOne {}
+function takes_alias(ExternalAlias $a): string {
+    return LocalTwo::class;
+}
+PHP,
+                '/tmp/edge-use-alias.php',
+            ],
+            'anonymous_class_and_named_class' => [
+                <<<'PHP'
+<?php
+namespace Edge\Four;
+$v = new class () {
+    public function x(): string { return 'y'; }
+};
+class NamedAfterAnonymous {}
+PHP,
+                '/tmp/edge-anon.php',
+            ],
+            'traits_and_nested_namespace_blocks' => [
+                <<<'PHP'
+<?php
+namespace Edge\Five\A {
+    trait SharedA {}
+    class UseA {
+        use SharedA;
+    }
+}
+namespace Edge\Five\B {
+    trait SharedB {}
+    class UseB {
+        use SharedB;
+    }
+}
+PHP,
+                '/tmp/edge-traits.php',
+            ],
+            'modern_types_attributes_and_match' => [
+                <<<'PHP'
+<?php
+namespace Edge\Six;
+#[\Attribute]
+class Marker {}
+#[Marker]
+class Advanced {
+    public function run(int|string $x): string {
+        return match (true) {
+            is_int($x) => 'int',
+            default => 'string',
+        };
+    }
+}
+PHP,
+                '/tmp/edge-modern.php',
+            ],
+            'enum_and_readonly_class_presence' => [
+                <<<'PHP'
+<?php
+namespace Edge\Seven;
+enum Status: string {
+    case READY = 'ready';
+}
+readonly class Holder {
+    public function __construct(public string $id) {}
+}
+PHP,
+                '/tmp/edge-enum-readonly.php',
+            ],
+        ];
+    }
+
+    private function assertScannerParity(string $contents, string $sourcePath): void
+    {
+        $legacyScanner = $this->newScanner(LegacyGetFromStringScanner::class);
+        $modernScanner = $this->newScanner(ScannerHarness::class);
+
+        $legacySymbols = $legacyScanner->scanString($contents, new File($sourcePath, basename($sourcePath)));
+        $modernSymbols = $modernScanner->scanString($contents, new File($sourcePath . '.new', basename($sourcePath . '.new')));
+
+        self::assertSame(
+            $this->snapshotSymbols($legacySymbols),
+            $this->snapshotSymbols($modernSymbols)
+        );
+    }
+
+    /**
+     * @param class-string<ScannerHarness> $scannerClass
+     */
+    private function newScanner(string $scannerClass): ScannerHarness
+    {
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $config->method('getProjectDirectory')->willReturn('/project');
+        $config->method('getPackagesToPrefix')->willReturn([]);
+
+        /** @var FileSystem&\Mockery\MockInterface $filesystem */
+        $filesystem = Mockery::mock(FileSystem::class);
+
+        return new $scannerClass(
+            $config,
+            new DiscoveredSymbols(),
+            $filesystem,
+            $this->getLogger()
+        );
+    }
+
+    /**
+     * @return array{
+     *     namespaces: array<int,string>,
+     *     classes: array<string,array{namespace:?string,abstract:bool,extends:?string,interfaces:array<int,string>}>,
+     *     functions: array<int,string>,
+     *     constants: array<int,string>,
+     *     interfaces: array<string,array{namespace:?string,extends:array<int,string>}>,
+     *     traits: array<string,array{namespace:?string,uses:array<int,string>}>
+     * }
+     */
+    private function snapshotSymbols(DiscoveredSymbols $symbols): array
+    {
+        $namespaces = array_keys($symbols->getNamespaces());
+        sort($namespaces);
+
+        $classes = [];
+        foreach ($symbols->getAllClasses() as $name => $classSymbol) {
+            assert($classSymbol instanceof ClassSymbol);
+            $interfaces = $classSymbol->getInterfaces();
+            sort($interfaces);
+
+            $classes[$name] = [
+                'namespace' => $classSymbol->getNamespace(),
+                'abstract' => $classSymbol->isAbstract(),
+                'extends' => $classSymbol->getExtends(),
+                'interfaces' => $interfaces,
+            ];
+        }
+        ksort($classes);
+
+        $functions = array_keys($symbols->getDiscoveredFunctions());
+        sort($functions);
+
+        $constants = array_keys($symbols->getConstants());
+        sort($constants);
+
+        $interfaces = [];
+        foreach ($symbols->getDiscoveredInterfaces() as $name => $interfaceSymbol) {
+            assert($interfaceSymbol instanceof InterfaceSymbol);
+            $extends = $interfaceSymbol->getExtends();
+            sort($extends);
+            $interfaces[$name] = [
+                'namespace' => $interfaceSymbol->getNamespace(),
+                'extends' => $extends,
+            ];
+        }
+        ksort($interfaces);
+
+        $traits = [];
+        foreach ($symbols->getDiscoveredTraits() as $name => $traitSymbol) {
+            assert($traitSymbol instanceof TraitSymbol);
+            $uses = $traitSymbol->getUses();
+            sort($uses);
+            $traits[$name] = [
+                'namespace' => $traitSymbol->getNamespace(),
+                'uses' => $uses,
+            ];
+        }
+        ksort($traits);
+
+        return [
+            'namespaces' => $namespaces,
+            'classes' => $classes,
+            'functions' => $functions,
+            'constants' => $constants,
+            'interfaces' => $interfaces,
+            'traits' => $traits,
+        ];
+    }
+}
+
+class ScannerHarness extends FileSymbolScanner
+{
+    public function scanString(string $contents, FileBase $file): DiscoveredSymbols
+    {
+        $this->find($contents, $file, null);
+
+        return $this->discoveredSymbols;
+    }
+}
+
+final class LegacyGetFromStringScanner extends ScannerHarness
+{
+    protected function parsePhpCode(string $contents): ParserContainer
+    {
+        return PhpCodeParser::getFromString($contents);
+    }
+}

--- a/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
+++ b/tests/Unit/Pipeline/FileSymbolScannerParserParityTest.php
@@ -14,6 +14,8 @@ use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
 use BrianHenryIE\Strauss\Types\InterfaceSymbol;
 use BrianHenryIE\Strauss\Types\TraitSymbol;
 use Mockery;
+use PhpParser\Error;
+use PhpParser\ParserFactory;
 
 /**
  * @covers \BrianHenryIE\Strauss\Pipeline\FileSymbolScanner
@@ -93,6 +95,15 @@ PHP;
     public static function edgeCaseProvider(): array
     {
         return [
+            'plain_global_file' => [
+                <<<'PHP'
+<?php
+function plain_global_helper() {
+    return true;
+}
+PHP,
+                '/tmp/plain-global.php',
+            ],
             'namespace_keyword_in_string_and_namespace_operator' => [
                 <<<'PHP'
 <?php
@@ -206,13 +217,50 @@ PHP,
         ];
     }
 
+    private function countOpeningTags(string $contents): int
+    {
+        $count = 0;
+        foreach (token_get_all($contents) as $token) {
+            if (is_array($token) && $token[0] === T_OPEN_TAG) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param string[] $parserInputs
+     */
+    private function assertParserInputsAreValid(array $parserInputs): void
+    {
+        self::assertNotEmpty($parserInputs);
+
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        foreach ($parserInputs as $parserInput) {
+            self::assertSame(
+                1,
+                $this->countOpeningTags($parserInput),
+                'Scanner namespace split should produce exactly one PHP opening tag per parser input.'
+            );
+
+            try {
+                $parser->parse($parserInput);
+            } catch (Error $e) {
+                self::fail('Scanner namespace split produced invalid PHP: ' . $e->getMessage());
+            }
+        }
+    }
+
     private function assertScannerParity(string $contents, string $sourcePath): void
     {
         $legacyScanner = $this->newScanner(LegacyGetFromStringScanner::class);
-        $modernScanner = $this->newScanner(ScannerHarness::class);
+        /** @var RecordingParserInputScanner $modernScanner */
+        $modernScanner = $this->newScanner(RecordingParserInputScanner::class);
 
         $legacySymbols = $legacyScanner->scanString($contents, new File($sourcePath, basename($sourcePath)));
         $modernSymbols = $modernScanner->scanString($contents, new File($sourcePath . '.new', basename($sourcePath . '.new')));
+        $this->assertParserInputsAreValid($modernScanner->getParserInputs());
 
         self::assertSame(
             $this->snapshotSymbols($legacySymbols),
@@ -326,5 +374,26 @@ final class LegacyGetFromStringScanner extends ScannerHarness
     protected function parsePhpCode(string $contents): ParserContainer
     {
         return PhpCodeParser::getFromString($contents);
+    }
+}
+
+final class RecordingParserInputScanner extends ScannerHarness
+{
+    /** @var string[] */
+    private array $parserInputs = [];
+
+    /**
+     * @return string[]
+     */
+    public function getParserInputs(): array
+    {
+        return $this->parserInputs;
+    }
+
+    protected function parsePhpCode(string $contents): ParserContainer
+    {
+        $this->parserInputs[] = $contents;
+
+        return parent::parsePhpCode($contents);
     }
 }

--- a/tests/Unit/Pipeline/FileSymbolScannerPerformanceTest.php
+++ b/tests/Unit/Pipeline/FileSymbolScannerPerformanceTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\Strauss\Composer\ComposerPackage;
+use BrianHenryIE\Strauss\Config\FileSymbolScannerConfigInterface;
+use BrianHenryIE\Strauss\Files\DiscoveredFiles;
+use BrianHenryIE\Strauss\Files\File;
+use BrianHenryIE\Strauss\Files\FileWithDependency;
+use BrianHenryIE\Strauss\Helpers\FileSystem;
+use BrianHenryIE\Strauss\TestCase;
+use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
+use Mockery;
+
+/**
+ * @covers \BrianHenryIE\Strauss\Pipeline\FileSymbolScanner
+ */
+class FileSymbolScannerPerformanceTest extends TestCase
+{
+    public function test_parser_reuse_does_not_leak_namespaces_across_files(): void
+    {
+        $firstContents = <<<'EOD'
+<?php
+namespace FirstNs {
+    class FirstNamespaced {}
+}
+namespace {
+    class FirstGlobal {}
+}
+EOD;
+
+        $secondContents = <<<'EOD'
+<?php
+namespace SecondNs {
+    class SecondNamespaced {}
+}
+namespace {
+    class SecondGlobal {}
+}
+EOD;
+
+        $filesystemReaderMock = Mockery::mock(FileSystem::class);
+        $filesystemReaderMock->expects('read')->twice()->andReturn($firstContents, $secondContents);
+        $filesystemReaderMock->expects('getRelativePath')->twice()->andReturn('vendor/vendor-a/one.php', 'vendor/vendor-a/two.php');
+
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $config->method('getProjectDirectory')->willReturn('/project');
+        $config->method('getPackagesToPrefix')->willReturn([]);
+        $discoveredSymbols = new DiscoveredSymbols();
+        $sut = new FileSymbolScanner($config, $discoveredSymbols, $filesystemReaderMock);
+
+        $fileOne = Mockery::mock(File::class);
+        $fileOne->shouldReceive('isPhpFile')->andReturnTrue();
+        $fileOne->shouldReceive('getTargetRelativePath');
+        $fileOne->shouldReceive('getDependency');
+        $fileOne->shouldReceive('addDiscoveredSymbol');
+        $fileOne->shouldReceive('getSourcePath')->andReturn('/a/path-one.php');
+
+        $fileTwo = Mockery::mock(File::class);
+        $fileTwo->shouldReceive('isPhpFile')->andReturnTrue();
+        $fileTwo->shouldReceive('getTargetRelativePath');
+        $fileTwo->shouldReceive('getDependency');
+        $fileTwo->shouldReceive('addDiscoveredSymbol');
+        $fileTwo->shouldReceive('getSourcePath')->andReturn('/a/path-two.php');
+
+        $discoveredFiles = Mockery::mock(DiscoveredFiles::class);
+        $discoveredFiles->shouldReceive('getFiles')->once()->andReturn([$fileOne, $fileTwo]);
+
+        $result = $sut->findInFiles($discoveredFiles);
+
+        self::assertArrayHasKey('FirstNs', $result->getDiscoveredNamespaces());
+        self::assertArrayHasKey('SecondNs', $result->getDiscoveredNamespaces());
+        self::assertContains('FirstGlobal', $result->getDiscoveredClasses());
+        self::assertContains('SecondGlobal', $result->getDiscoveredClasses());
+    }
+
+    public function test_string_containing_namespace_keyword_is_ignored(): void
+    {
+        $contents = <<<'EOD'
+<?php
+$statement = "namespace Fake\Namespace;";
+
+function keep_global() {
+    return true;
+}
+EOD;
+
+        $result = $this->scanContentForSymbols($contents);
+
+        self::assertEmpty($result->getDiscoveredNamespaces());
+        self::assertArrayHasKey('keep_global', $result->getDiscoveredFunctions());
+    }
+
+    public function test_namespace_operator_does_not_create_additional_namespace(): void
+    {
+        $contents = <<<'EOD'
+<?php
+namespace Demo;
+
+function read_length(string $input): int {
+    return namespace\strlen($input);
+}
+EOD;
+
+        $result = $this->scanContentForSymbols($contents);
+
+        self::assertArrayHasKey('Demo', $result->getDiscoveredNamespaces());
+        self::assertArrayNotHasKey('strlen', $result->getDiscoveredNamespaces());
+        self::assertArrayHasKey('Demo\\read_length', $result->getDiscoveredFunctions());
+    }
+
+    /**
+     * @dataProvider namespaceTokenContextProvider
+     *
+     * @param string[] $expectedNamespaces
+     * @param string[] $absentNamespaces
+     * @param string[] $expectedFunctions
+     */
+    public function test_namespace_token_detection_ignores_non_declaration_contexts(
+        string $contents,
+        array $expectedNamespaces,
+        array $absentNamespaces,
+        array $expectedFunctions
+    ): void {
+        $result = $this->scanContentForSymbols($contents);
+
+        foreach ($expectedNamespaces as $namespace) {
+            self::assertArrayHasKey($namespace, $result->getDiscoveredNamespaces());
+        }
+        foreach ($absentNamespaces as $namespace) {
+            self::assertArrayNotHasKey($namespace, $result->getDiscoveredNamespaces());
+        }
+        foreach ($expectedFunctions as $function) {
+            self::assertArrayHasKey($function, $result->getDiscoveredFunctions());
+        }
+    }
+
+    /**
+     * @return array<string,array{0:string,1:array<int,string>,2:array<int,string>,3:array<int,string>}>
+     */
+    public static function namespaceTokenContextProvider(): array
+    {
+        return [
+            'heredoc and nowdoc text' => [
+                <<<'PHP'
+<?php
+$heredoc = <<<TXT
+namespace Fake\Heredoc;
+TXT;
+$nowdoc = <<<'TXT'
+namespace Fake\Nowdoc;
+TXT;
+function keep_template_text() {
+    return true;
+}
+PHP,
+                [],
+                ['Fake\\Heredoc', 'Fake\\Nowdoc'],
+                ['keep_template_text'],
+            ],
+            'attribute argument string' => [
+                <<<'PHP'
+<?php
+namespace AttrDemo;
+#[Marker("namespace Fake\Attribute;")]
+class WithAttribute {}
+function attr_helper() {
+    return true;
+}
+PHP,
+                ['AttrDemo'],
+                ['Fake\\Attribute'],
+                ['AttrDemo\\attr_helper'],
+            ],
+            'declare before namespace' => [
+                <<<'PHP'
+<?php
+declare(strict_types=1);
+namespace DeclaredDemo;
+function declared_helper() {
+    return true;
+}
+PHP,
+                ['DeclaredDemo'],
+                [],
+                ['DeclaredDemo\\declared_helper'],
+            ],
+        ];
+    }
+
+    public function test_dependency_file_outside_packages_to_prefix_sets_do_prefix_false(): void
+    {
+        $contents = <<<'EOD'
+<?php
+function scan_me() {
+    return true;
+}
+EOD;
+
+        $filesystemReaderMock = Mockery::mock(FileSystem::class);
+        $filesystemReaderMock->expects('read')->once()->andReturn($contents);
+        $filesystemReaderMock->expects('getRelativePath')->never();
+
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $config->method('getProjectDirectory')->willReturn('/project');
+        $config->method('getPackagesToPrefix')->willReturn([
+            'vendor/vendor-b' => $this->createMock(ComposerPackage::class),
+        ]);
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $sut = new FileSymbolScanner($config, $discoveredSymbols, $filesystemReaderMock);
+
+        /** @var ComposerPackage&\Mockery\MockInterface $dependency */
+        $dependency = Mockery::mock(ComposerPackage::class);
+        $dependency->shouldReceive('getPackageName')->andReturn('vendor/vendor-a');
+        $dependency->shouldReceive('getPackageAbsolutePath')->andReturn('/project/vendor/vendor-a/');
+        $dependency->shouldReceive('addFile')->once();
+
+        $file = new FileWithDependency(
+            $dependency,
+            'vendor/vendor-a/file.php',
+            '/project/vendor/vendor-a/file.php'
+        );
+        $file->setDoPrefix(true);
+
+        $discoveredFiles = new DiscoveredFiles();
+        $discoveredFiles->add($file);
+
+        $result = $sut->findInFiles($discoveredFiles);
+
+        self::assertArrayHasKey('scan_me', $result->getDiscoveredFunctions());
+        self::assertFalse($file->isDoPrefix());
+    }
+
+    public function test_dependency_file_inside_packages_to_prefix_does_not_set_do_prefix_false(): void
+    {
+        $contents = <<<'EOD'
+<?php
+function scan_me_too() {
+    return true;
+}
+EOD;
+
+        $filesystemReaderMock = Mockery::mock(FileSystem::class);
+        $filesystemReaderMock->expects('read')->once()->andReturn($contents);
+        $filesystemReaderMock->expects('getRelativePath')->never();
+
+        /** @var ComposerPackage&\Mockery\MockInterface $dependency */
+        $dependency = Mockery::mock(ComposerPackage::class);
+        $dependency->shouldReceive('getPackageName')->andReturn('vendor/vendor-a');
+        $dependency->shouldReceive('getPackageAbsolutePath')->andReturn('/project/vendor/vendor-a/');
+        $dependency->shouldReceive('addFile')->once();
+
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $config->method('getProjectDirectory')->willReturn('/project');
+        $config->method('getPackagesToPrefix')->willReturn([
+            'vendor/vendor-a' => $dependency,
+        ]);
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $sut = new FileSymbolScanner($config, $discoveredSymbols, $filesystemReaderMock);
+
+        $file = new FileWithDependency(
+            $dependency,
+            'vendor/vendor-a/file.php',
+            '/project/vendor/vendor-a/file.php'
+        );
+        $file->setDoPrefix(true);
+
+        $discoveredFiles = new DiscoveredFiles();
+        $discoveredFiles->add($file);
+
+        $result = $sut->findInFiles($discoveredFiles);
+
+        self::assertArrayHasKey('scan_me_too', $result->getDiscoveredFunctions());
+        self::assertTrue($file->isDoPrefix());
+    }
+
+    private function scanContentForSymbols(string $contents): DiscoveredSymbols
+    {
+        $filesystemReaderMock = Mockery::mock(FileSystem::class);
+        $filesystemReaderMock->expects('read')->once()->andReturn($contents);
+        $filesystemReaderMock->expects('getRelativePath')->once()->andReturnArg(1);
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $config = $this->createMock(FileSymbolScannerConfigInterface::class);
+        $config->method('getProjectDirectory')->willReturn('/project');
+        $config->method('getPackagesToPrefix')->willReturn([]);
+        $sut = new FileSymbolScanner($config, $discoveredSymbols, $filesystemReaderMock);
+
+        $file = Mockery::mock(File::class);
+        $file->shouldReceive('isPhpFile')->andReturnTrue();
+        $file->shouldReceive('getTargetRelativePath');
+        $file->shouldReceive('getDependency');
+        $file->shouldReceive('addDiscoveredSymbol');
+        $file->shouldReceive('getSourcePath')->andReturn('/a/path');
+
+        $discoveredFiles = Mockery::mock(DiscoveredFiles::class);
+        $discoveredFiles->shouldReceive('getFiles')->andReturn([$file]);
+
+        return $sut->findInFiles($discoveredFiles);
+    }
+}

--- a/tests/Unit/Pipeline/LegacyGetFromStringScanner.php
+++ b/tests/Unit/Pipeline/LegacyGetFromStringScanner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserContainer;
+use BrianHenryIE\SimplePhpParser\Parsers\PhpCodeParser;
+
+final class LegacyGetFromStringScanner extends ScannerHarness
+{
+    protected function parsePhpCode(string $contents): ParserContainer
+    {
+        return PhpCodeParser::getFromString($contents);
+    }
+}

--- a/tests/Unit/Pipeline/RecordingParserInputScanner.php
+++ b/tests/Unit/Pipeline/RecordingParserInputScanner.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\SimplePhpParser\Parsers\Helper\ParserContainer;
+
+final class RecordingParserInputScanner extends ScannerHarness
+{
+    /** @var string[] */
+    private array $parserInputs = [];
+
+    /**
+     * @return string[]
+     */
+    public function getParserInputs(): array
+    {
+        return $this->parserInputs;
+    }
+
+    protected function parsePhpCode(string $contents): ParserContainer
+    {
+        $this->parserInputs[] = $contents;
+
+        return parent::parsePhpCode($contents);
+    }
+}

--- a/tests/Unit/Pipeline/ScannerHarness.php
+++ b/tests/Unit/Pipeline/ScannerHarness.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Pipeline;
+
+use BrianHenryIE\Strauss\Files\FileBase;
+use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
+
+class ScannerHarness extends FileSymbolScanner
+{
+    public function scanString(string $contents, FileBase $file): DiscoveredSymbols
+    {
+        $this->find($contents, $file, null);
+
+        return $this->discoveredSymbols;
+    }
+}

--- a/tests/Unit/PrefixerParseErrorHarness.php
+++ b/tests/Unit/PrefixerParseErrorHarness.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BrianHenryIE\Strauss;
+
+use BrianHenryIE\Strauss\Pipeline\Prefixer;
+use BrianHenryIE\Strauss\Types\NamespaceSymbol;
+
+class PrefixerParseErrorHarness extends Prefixer
+{
+    /**
+     * @param array<string,string> $functionReplacementMap
+     */
+    public function callReplaceFunctionsBatch(string $contents, array $functionReplacementMap): string
+    {
+        return $this->replaceFunctionsBatch($contents, $functionReplacementMap);
+    }
+
+    /**
+     * @param array<string,NamespaceSymbol> $namespaceSymbols
+     */
+    public function callReplaceConstFetchNamespacesByMap(array $namespaceSymbols, string $contents): string
+    {
+        return $this->replaceConstFetchNamespacesByMap($namespaceSymbols, $contents);
+    }
+
+    /**
+     * @param NamespaceSymbol[] $namespaceSymbols
+     */
+    public function callPrepareRelativeNamespaces(string $contents, array $namespaceSymbols): string
+    {
+        return $this->prepareRelativeNamespaces($contents, $namespaceSymbols);
+    }
+}

--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -13,6 +13,7 @@ use BrianHenryIE\Strauss\Files\File;
 use BrianHenryIE\Strauss\Pipeline\Prefixer;
 use BrianHenryIE\Strauss\TestCase;
 use BrianHenryIE\Strauss\Tests\Issues\MozartIssue93Test;
+use BrianHenryIE\Strauss\Tests\PhpAstAssertions;
 use BrianHenryIE\Strauss\Types\ClassSymbol;
 use BrianHenryIE\Strauss\Types\ConstantSymbol;
 use BrianHenryIE\Strauss\Types\DiscoveredSymbols;
@@ -31,6 +32,8 @@ use PHPUnit\Framework\MockObject\Exception;
  */
 class PrefixerTest extends TestCase
 {
+    use PhpAstAssertions;
+
     public function testNamespaceReplacer(): void
     {
 
@@ -2027,6 +2030,230 @@ EOD;
         $this->assertEqualsRN($expected, $result);
     }
 
+    public function testReplaceMultipleFunctionsAndKeepMethodsUntouched(): void
+    {
+        $contents = <<<'EOD'
+<?php
+if (! function_exists('first_fn')) {
+    function first_fn()
+    {
+        return 1;
+    }
+}
+if (! function_exists('second_fn')) {
+    function second_fn()
+    {
+        return 2;
+    }
+}
+
+class ExampleClass
+{
+    public function first_fn()
+    {
+        return 'method';
+    }
+}
+
+$a = first_fn();
+$b = second_fn();
+call_user_func('first_fn');
+call_user_func_array('second_fn', []);
+$c = (new ExampleClass())->first_fn();
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+
+        $symbols = new DiscoveredSymbols();
+
+        $fileMock = $this->createMock(File::class);
+        $fileMock->expects($this->any())
+                 ->method('isDoPrefix')
+                 ->willReturn(true);
+
+        $firstFunctionSymbol = new FunctionSymbol('first_fn', $fileMock);
+        $firstFunctionSymbol->setReplacement('pref_first_fn');
+        $symbols->add($firstFunctionSymbol);
+
+        $secondFunctionSymbol = new FunctionSymbol('second_fn', $fileMock);
+        $secondFunctionSymbol->setReplacement('pref_second_fn');
+        $symbols->add($secondFunctionSymbol);
+
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $result = $replacer->replaceInString($symbols, $contents);
+
+        self::assertSame(['pref_first_fn', 'pref_second_fn'], $this->getFunctionDeclarationNames($result));
+        self::assertSame(['first_fn'], $this->getClassMethodNames($result));
+        self::assertContains('pref_first_fn', $this->getFunctionCallNames($result));
+        self::assertContains('pref_second_fn', $this->getFunctionCallNames($result));
+        self::assertNotContains('first_fn', $this->getFunctionCallNames($result));
+        self::assertNotContains('second_fn', $this->getFunctionCallNames($result));
+        self::assertSame(
+            ['pref_first_fn', 'pref_second_fn', 'pref_first_fn', 'pref_second_fn'],
+            $this->getCallableStringValues($result)
+        );
+    }
+
+    public function testReplaceFunctionsPreservesLegacyCascadingBehavior(): void
+    {
+        $contents = <<<'EOD'
+<?php
+function foo() {}
+function pref_foo() {}
+
+foo();
+pref_foo();
+call_user_func('foo');
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+
+        $symbols = new DiscoveredSymbols();
+
+        $fileMock = $this->createMock(File::class);
+        $fileMock->expects($this->any())
+                 ->method('isDoPrefix')
+                 ->willReturn(true);
+
+        $firstFunctionSymbol = new FunctionSymbol('foo', $fileMock);
+        $firstFunctionSymbol->setReplacement('pref_foo');
+        $symbols->add($firstFunctionSymbol);
+
+        $secondFunctionSymbol = new FunctionSymbol('pref_foo', $fileMock);
+        $secondFunctionSymbol->setReplacement('pref_pref_foo');
+        $symbols->add($secondFunctionSymbol);
+
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $result = $replacer->replaceInString($symbols, $contents);
+
+        self::assertSame(['pref_pref_foo', 'pref_pref_foo'], $this->getFunctionDeclarationNames($result));
+        self::assertSame(
+            ['pref_pref_foo', 'pref_pref_foo', 'call_user_func'],
+            $this->getFunctionCallNames($result)
+        );
+        self::assertSame(['pref_pref_foo'], $this->getCallableStringValues($result));
+    }
+
+    public function testReplaceFunctionsLeavesUnmappedCallableStringsUnchanged(): void
+    {
+        $contents = <<<'EOD'
+<?php
+function mapped_fn() {}
+
+mapped_fn();
+function_exists('mapped_fn');
+call_user_func('mapped_fn');
+
+function_exists('unmapped_fn');
+call_user_func('unmapped_fn');
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+
+        $symbols = new DiscoveredSymbols();
+
+        $fileMock = $this->createMock(File::class);
+        $fileMock->expects($this->any())
+                 ->method('isDoPrefix')
+                 ->willReturn(true);
+
+        $functionSymbol = new FunctionSymbol('mapped_fn', $fileMock);
+        $functionSymbol->setReplacement('pref_mapped_fn');
+        $symbols->add($functionSymbol);
+
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $result = $replacer->replaceInString($symbols, $contents);
+
+        self::assertSame(['pref_mapped_fn'], $this->getFunctionDeclarationNames($result));
+        self::assertContains('pref_mapped_fn', $this->getFunctionCallNames($result));
+        self::assertNotContains('mapped_fn', $this->getFunctionCallNames($result));
+        self::assertSame(
+            ['pref_mapped_fn', 'pref_mapped_fn', 'unmapped_fn', 'unmapped_fn'],
+            $this->getCallableStringValues($result)
+        );
+    }
+
+    public function testReplaceFunctionsBatchReturnsOriginalContentOnParseError(): void
+    {
+        $contents = "<?php\nfunction broken( {\n";
+        $replacer = new PrefixerParseErrorHarness(
+            $this->createMock(PrefixerConfigInterface::class),
+            $this->getInMemoryFileSystem(),
+            $this->getLogger()
+        );
+
+        $result = $replacer->callReplaceFunctionsBatch($contents, ['broken' => 'pref_broken']);
+
+        self::assertSame($contents, $result);
+        self::assertTrue($this->getTestLogger()->hasWarningThatContains('Skipping ::replaceFunctions()'));
+    }
+
+    public function testReplaceConstFetchNamespacesByMapReturnsOriginalContentOnParseError(): void
+    {
+        $contents = "<?php\nfunction broken( { return \\Vendor\\Package\\VALUE; }\n";
+        $file = $this->createMock(File::class);
+        $namespace = new NamespaceSymbol('Vendor\\Package', $file);
+        $namespace->setReplacement('Pref\\Vendor\\Package');
+        $replacer = new PrefixerParseErrorHarness(
+            $this->createMock(PrefixerConfigInterface::class),
+            $this->getInMemoryFileSystem(),
+            $this->getLogger()
+        );
+
+        $result = $replacer->callReplaceConstFetchNamespacesByMap(['Vendor\\Package' => $namespace], $contents);
+
+        self::assertSame($contents, $result);
+        self::assertTrue($this->getTestLogger()->hasWarningThatContains('Skipping ::replaceConstFetchNamespaces()'));
+    }
+
+    public function testPrepareRelativeNamespacesReturnsOriginalContentOnParseError(): void
+    {
+        $contents = "<?php\nfunction broken( { use Vendor\\Package\\TraitName; }\n";
+        $file = $this->createMock(File::class);
+        $namespace = new NamespaceSymbol('Vendor\\Package', $file);
+        $replacer = new PrefixerParseErrorHarness(
+            $this->createMock(PrefixerConfigInterface::class),
+            $this->getInMemoryFileSystem(),
+            $this->getLogger()
+        );
+
+        $result = $replacer->callPrepareRelativeNamespaces($contents, [$namespace]);
+
+        self::assertSame($contents, $result);
+        self::assertTrue($this->getTestLogger()->hasWarningThatContains('Skipping ::prepareRelativeNamespaces()'));
+    }
+
+    public function testReplaceNamespaceHandlesEscapedStringsThroughPrefilter(): void
+    {
+        $contents = <<<'EOD'
+<?php
+$singleEscaped = '\Vendor\Package\ClassName';
+$doubleEscaped = '\\Vendor\\Package\\ClassName';
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+
+        $symbols = new DiscoveredSymbols();
+
+        $fileMock = $this->createMock(File::class);
+        $fileMock->expects($this->any())
+                 ->method('isDoPrefix')
+                 ->willReturn(true);
+
+        $namespaceSymbol = new NamespaceSymbol('Vendor\Package', $fileMock);
+        $namespaceSymbol->setReplacement('Pref\Vendor\Package');
+        $symbols->add($namespaceSymbol);
+
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+        $result = $replacer->replaceInString($symbols, $contents);
+
+        $this->assertStringContainsString('\Pref\Vendor\Package\ClassName', $result);
+        $this->assertStringContainsString('\\Pref\\Vendor\\Package\\ClassName', $result);
+    }
+
     /**
      * @covers ::prepareRelativeNamespaces
      */
@@ -2930,5 +3157,32 @@ EOD;
         $result = $replacer->replaceInString($symbols, $contents);
 
         $this->assertEqualsRN($expected, $result);
+    }
+}
+
+class PrefixerParseErrorHarness extends Prefixer
+{
+    /**
+     * @param array<string,string> $functionReplacementMap
+     */
+    public function callReplaceFunctionsBatch(string $contents, array $functionReplacementMap): string
+    {
+        return $this->replaceFunctionsBatch($contents, $functionReplacementMap);
+    }
+
+    /**
+     * @param array<string,NamespaceSymbol> $namespaceSymbols
+     */
+    public function callReplaceConstFetchNamespacesByMap(array $namespaceSymbols, string $contents): string
+    {
+        return $this->replaceConstFetchNamespacesByMap($namespaceSymbols, $contents);
+    }
+
+    /**
+     * @param NamespaceSymbol[] $namespaceSymbols
+     */
+    public function callPrepareRelativeNamespaces(string $contents, array $namespaceSymbols): string
+    {
+        return $this->prepareRelativeNamespaces($contents, $namespaceSymbols);
     }
 }

--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -3203,30 +3203,3 @@ EOD;
         $this->assertEqualsRN($expected, $result);
     }
 }
-
-class PrefixerParseErrorHarness extends Prefixer
-{
-    /**
-     * @param array<string,string> $functionReplacementMap
-     */
-    public function callReplaceFunctionsBatch(string $contents, array $functionReplacementMap): string
-    {
-        return $this->replaceFunctionsBatch($contents, $functionReplacementMap);
-    }
-
-    /**
-     * @param array<string,NamespaceSymbol> $namespaceSymbols
-     */
-    public function callReplaceConstFetchNamespacesByMap(array $namespaceSymbols, string $contents): string
-    {
-        return $this->replaceConstFetchNamespacesByMap($namespaceSymbols, $contents);
-    }
-
-    /**
-     * @param NamespaceSymbol[] $namespaceSymbols
-     */
-    public function callPrepareRelativeNamespaces(string $contents, array $namespaceSymbols): string
-    {
-        return $this->prepareRelativeNamespaces($contents, $namespaceSymbols);
-    }
-}

--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -2101,9 +2101,11 @@ EOD;
 <?php
 function foo() {}
 function pref_foo() {}
+function pref_pref_foo() {}
 
 foo();
 pref_foo();
+pref_pref_foo();
 call_user_func('foo');
 EOD;
 
@@ -2124,16 +2126,58 @@ EOD;
         $secondFunctionSymbol->setReplacement('pref_pref_foo');
         $symbols->add($secondFunctionSymbol);
 
+        $thirdFunctionSymbol = new FunctionSymbol('pref_pref_foo', $fileMock);
+        $thirdFunctionSymbol->setReplacement('final_foo');
+        $symbols->add($thirdFunctionSymbol);
+
         $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
 
         $result = $replacer->replaceInString($symbols, $contents);
 
-        self::assertSame(['pref_pref_foo', 'pref_pref_foo'], $this->getFunctionDeclarationNames($result));
+        self::assertSame(['final_foo', 'final_foo', 'final_foo'], $this->getFunctionDeclarationNames($result));
         self::assertSame(
-            ['pref_pref_foo', 'pref_pref_foo', 'call_user_func'],
+            ['final_foo', 'final_foo', 'final_foo', 'call_user_func'],
             $this->getFunctionCallNames($result)
         );
-        self::assertSame(['pref_pref_foo'], $this->getCallableStringValues($result));
+        self::assertSame(['final_foo'], $this->getCallableStringValues($result));
+    }
+
+    public function testReplaceFunctionsDoesNotCascadeThroughEarlierSymbols(): void
+    {
+        $contents = <<<'EOD'
+<?php
+function foo() {}
+function pref_foo() {}
+
+foo();
+pref_foo();
+call_user_func('foo');
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+
+        $symbols = new DiscoveredSymbols();
+
+        $fileMock = $this->createMock(File::class);
+        $fileMock->expects($this->any())
+                 ->method('isDoPrefix')
+                 ->willReturn(true);
+
+        $firstFunctionSymbol = new FunctionSymbol('pref_foo', $fileMock);
+        $firstFunctionSymbol->setReplacement('final_foo');
+        $symbols->add($firstFunctionSymbol);
+
+        $secondFunctionSymbol = new FunctionSymbol('foo', $fileMock);
+        $secondFunctionSymbol->setReplacement('pref_foo');
+        $symbols->add($secondFunctionSymbol);
+
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $result = $replacer->replaceInString($symbols, $contents);
+
+        self::assertSame(['pref_foo', 'final_foo'], $this->getFunctionDeclarationNames($result));
+        self::assertSame(['pref_foo', 'final_foo', 'call_user_func'], $this->getFunctionCallNames($result));
+        self::assertSame(['pref_foo'], $this->getCallableStringValues($result));
     }
 
     public function testReplaceFunctionsLeavesUnmappedCallableStringsUnchanged(): void


### PR DESCRIPTION
# Performance improvements across the Strauss prefixing pipeline

## Anecdotal Performance Gains

I run Strauss against my [Shield Security](https://github.com/FernleafSystems/Shield-Security-for-WordPress) repo many times a day. Without any of these changes, the Strauss processing takes longer than 6 minutes! With these changes in-place, the Strauss replacements take between 40~44s consistently. That's a saving I gain of nearly 90% in time, not to mention the saving in machine processing.  We've been using most of these performance improvements privately in testing for nearly 2 months without issue- it's very stable.

## Purpose

This PR reduces avoidable work across the main Strauss prefixing pipeline while keeping the generated package output stable.

The branch focuses on four performance stages:

| Stage | Main hotspot | Commit |
| --- | --- | --- |
| Dependency package setup | Composer package metadata creation and dependency enumeration | `3bcb3ec0` |
| File symbol scanning | Parser setup, namespace splitting, and repeated lookup work | `ebcc801c` |
| Prefix replacements | Repeated replacement-map construction and repeated AST passes | `563db949` |
| Cleanup | `installed.json` probes, empty directory pruning, duplicate cleanup work, and filtered logging overhead | `3b07a52c` |

There is also one support commit, `85852013`, which adds integration-level scanning parity coverage so the scanner optimization has a stronger output-safety net.

The strategy throughout is to avoid repeated work rather than change Strauss semantics. The expected final state should remain the same: copied files, deleted files, generated autoload files, and decoded `installed.json` package/autoload data should match the previous behaviour.

## Commit walkthrough

### 1. Speed dependency package setup - `3bcb3ec0`

Problem:

The dependency setup path was doing more Composer work than Strauss needs for package metadata. Creating full Composer instances is relatively expensive when Strauss only needs package-level information such as name, version, autoload data, requirements, and path information.

What changed:

- `ComposerPackage` now builds from Composer's partial-load path for package metadata instead of full Composer loading.
- Platform package detection is centralised through `ComposerPackage::isPlatformPackageName()`.
- `DependenciesEnumerator` reuses that platform-package check when filtering virtual/platform requirements.
- `FileEnumerator` avoids routing already collected dependency file paths through the broader project path handling path.
- Package path resolution is a little more defensive where `realpath()` can fail, especially in non-standard or virtual filesystem contexts.

Why this helps:

The setup phase now avoids Composer initialization and path work that does not contribute to Strauss' dependency graph. This should mostly help projects with larger dependency trees, where repeated package metadata construction becomes visible.

### 2. Speed file symbol scanning - `ebcc801c`

Problem:

The scanner sits on a hot path because every relevant PHP file passes through it. The previous flow repeatedly created parser/pretty-printer objects, performed linear lookups for package and symbol membership, and used heavier namespace splitting even when a file had no namespace or only a single namespace.

What changed:

- Parser and pretty-printer instances are reused by `FileSymbolScanner`.
- Package and logged-symbol membership checks use lookup maps instead of repeated linear scans.
- Dependency files use their vendor-relative path directly where available.
- Namespace declarations are discovered with token scanning first.
- Files with no namespace or a single namespace avoid the expensive AST-based namespace split path.
- Parser processing now reuses the existing `ParserContainer`/visitor flow so derived class/interface relationships are still populated.

Why this helps:

This removes repeated object creation and reduces parser work on the common cases. Files that do not need full namespace splitting now stay on a cheaper path, while multi-namespace files still retain the existing AST-based handling.

### 3. Batch prefix replacements - `563db949`

Problem:

The replacement phase was repeatedly rebuilding replacement information and revisiting the same file contents for different symbol types. Function replacement was especially expensive because it could trigger repeated parser and AST traversal work per symbol.

What changed:

- `Prefixer` now builds a replacement context once for the current discovered symbol set.
- File and project replacement flows reuse that context across files.
- Parser and `NodeFinder` instances are reused inside the prefixer.
- Function declarations, calls, and callable-string arguments are handled in a batched AST pass.
- Namespace replacement paths include cheap guards so Strauss can skip work when the file cannot contain the relevant namespace representation.
- The public `replaceInString()` behaviour remains available by building a context internally for that single call.

Why this helps:

The prefixer now pays the setup cost once per replacement run instead of repeating it for each symbol/file combination. The batched function handling is the main practical win here: fewer parser passes, fewer full-file scans, and fewer repeated replacement-map builds.

### 4. Add scanning parity coverage - `85852013`

Problem:

The scanner optimization changes how Strauss reaches the discovered-symbol result. That creates a risk that performance improvements could accidentally preserve unit-level behaviour while changing integrated prefixed output.

What changed:

- Adds integration coverage for scanner parity across named namespaces, global namespace declarations, functions, constants, classes, consumers, and multi-namespace files.
- Tightens path-normalizer setup around `ComposerPackage` so the tests exercise stable path behaviour.

Why this helps:

This commit is not a runtime optimization. It is a safety commit for the scanner changes, proving that the optimized discovery path still feeds the downstream prefixing pipeline correctly.

### 5. Optimize cleanup without changing package output - `3b07a52c`

Problem:

The `"Cleaning up..."` step had several sources of repeated overhead:

- `InstalledJson` repeatedly checked the same paths while validating autoload entries.
- Package and exclusion membership checks used repeated array scans.
- Empty-directory pruning walked recursive file listings and checked many file paths as possible directories.
- The normal command flow could clean target `installed.json` more than once.
- Monolog still processed hidden `info`/`debug` records even when normal CLI output would suppress them.

What changed:

- `InstalledJson` now uses per-pass caches for file and directory existence checks.
- Dependency and `exclude_from_copy.packages` membership checks use prebuilt lookup maps.
- Empty-directory pruning collects directory entries from the recursive listing, sorts deepest-first, and avoids `directoryExists()` checks for file entries.
- `DependenciesCommand` coordinates target/vendor `installed.json` cleanup directly so the normal command path does not duplicate target cleanup work.
- Standalone `Autoload::generate()` still performs target `installed.json` cleanup through its existing path; command-level cleanup only covers cases where the command will not rely on that path.
- Standalone `Cleanup::cleanupVendorInstalledJson()` behaviour remains intact.
- No `Autoload` constructor change was needed.
- `AbstractRenamespacerCommand` now sets the Monolog handler level from CLI verbosity:
  - normal output processes `notice+`
  - `--info` processes `info+`
  - `--debug` and dry-run process `debug+`
  - silent output avoids handler/processor work
- `FileSystem` path normalization was adjusted for stream wrappers and Windows drive paths so `JsonFile` and dry-run paths stay reliable.

Why this helps:

Cleanup now avoids repeated filesystem probes and repeated metadata scans. Directory pruning also does less work on large vendor trees because it only evaluates directory entries as deletion candidates. The logging change removes hidden processor cost from normal runs without changing visible default output.

The cleanup gains are mostly overhead reductions. If a repository's cleanup time is dominated by physical file deletion, Composer autoload rebuilding, Windows filesystem latency, antivirus scanning, or slow storage, this commit may not produce a large wall-clock change by itself.

## Compatibility and behaviour

- No config schema change.
- No constructor contract change.
- No intended change to copied/deleted filesystem artifacts.
- No intended change to generated autoload output.
- No intended change to decoded `installed.json` package/autoload decisions.
- Standalone `Autoload::generate()` and `Cleanup::cleanupVendorInstalledJson()` callers keep their existing public call paths.
- Visible CLI output behaviour should remain the same at normal, `--info`, `--debug`, dry-run, and silent levels.

The only intentional internal behaviour change is that log records below the active CLI verbosity no longer pay Monolog processor cost before being filtered out.

## Test and validation summary

The branch adds focused tests around the changed hot paths rather than broad test bulk for its own sake:

- Composer package factory parity and platform package handling.
- Dependency and file enumeration behaviour.
- Scanner parser parity, namespace handling, and performance-sensitive scanner cases.
- Prefixer semantic checks for classes, namespaces, constants, functions, callable strings, and batched replacement behaviour.
- Integration-level scanning parity through the full prefixing pipeline.
- Cleanup package filtering for target/vendor `installed.json`.
- Cleanup autoload path filtering across `files`, `classmap`, `psr-0`, and `psr-4`.
- Vendor file/package deletion and empty-directory pruning.
- Logger verbosity/processor filtering.
- Filesystem path normalization for stream-wrapper and Windows-style paths.

Validation run locally included the focused cleanup/autoload tests, cleanup integrations, output-level coverage, selected issue regressions around cleanup/delete/exclude behaviour, and broad `Cleanup|InstalledJson|Autoload` filtering. The broad filter still reaches existing Windows temp-path failures in `tests/Unit/Composer/Extra/StraussConfigTest.php`; those are outside this performance change and were not altered in this branch.

## Reviewer notes

This PR deliberately keeps the implementation scoped to eliminating repeated work in existing flows. It avoids changing the public configuration surface or adding constructor parameters for coordination between pipeline stages.

The cleanup optimization is included because it removes real repeated work, but it should be viewed as one part of the wider performance branch. On some projects, the cleanup wall-clock time may still be dominated by external filesystem and Composer work rather than the PHP-level overhead reduced here.
