### PR TITLE
Bugfix: Reindex installed.json package lists before writing

### DIFF
--- a/src/Pipeline/Cleanup/InstalledJson.php
+++ b/src/Pipeline/Cleanup/InstalledJson.php
@@ -513,6 +513,7 @@ class InstalledJson
             }
         }
 
+        $installedJsonArray = $this->reindexPackagesList($installedJsonArray);
         $installedJsonArray['dev'] = false;
         $installedJsonArray['dev-package-names'] = [];
 
@@ -566,10 +567,23 @@ class InstalledJson
         // Only relevant when source = target.
         $installedJsonArray = $this->updateNamespaces($installedJsonArray, $discoveredSymbols);
 
+        $installedJsonArray = $this->reindexPackagesList($installedJsonArray);
+
         if (!$this->config->isDryRun()) {
             $vendorInstalledJsonFile->write($installedJsonArray);
         }
 
         $this->logger->debug('Finished InstalledJson::cleanupVendorInstalledJson()');
+    }
+
+    /**
+     * @param InstalledJsonArray $installedJsonArray
+     * @return InstalledJsonArray
+     */
+    private function reindexPackagesList(array $installedJsonArray): array
+    {
+        $installedJsonArray['packages'] = array_values($installedJsonArray['packages']);
+
+        return $installedJsonArray;
     }
 }

--- a/tests/Integration/Cleanup/InstalledJsonIntegrationTest.php
+++ b/tests/Integration/Cleanup/InstalledJsonIntegrationTest.php
@@ -9,6 +9,47 @@ use BrianHenryIE\Strauss\IntegrationTestCase;
  */
 class InstalledJsonIntegrationTest extends IntegrationTestCase
 {
+    public function testVendorInstalledJsonPackagesRemainAListAfterDeletedPackagesAreRemoved(): void
+    {
+        chdir($this->testsWorkingDir);
+        $this->createDeletedParentWithExcludedDependencyFixture();
+
+        exec('composer install --no-interaction --no-progress --no-ansi', $output, $exitCode);
+        $this->assertEquals(0, $exitCode, implode(PHP_EOL, $output));
+
+        $exitCode = $this->runStrauss($straussOutput);
+        $this->assertEquals(0, $exitCode, $straussOutput);
+
+        $packageNames = $this->assertInstalledJsonPackagesIsList(
+            $this->getFileSystem()->read($this->testsWorkingDir . '/vendor/composer/installed.json')
+        );
+
+        $this->assertSame(['acme/preserved-files'], $packageNames);
+    }
+
+    public function testTargetInstalledJsonPackagesRemainAListAfterNonStraussPackagesAreRemoved(): void
+    {
+        chdir($this->testsWorkingDir);
+        $this->createTargetPackageRemovalFixture();
+
+        exec('composer install --no-interaction --no-progress --no-ansi', $output, $exitCode);
+        $this->assertEquals(0, $exitCode, implode(PHP_EOL, $output));
+
+        $exitCode = $this->runStrauss($straussOutput);
+        $this->assertEquals(0, $exitCode, $straussOutput);
+
+        $packageNames = $this->assertInstalledJsonPackagesIsList(
+            $this->getFileSystem()->read($this->testsWorkingDir . '/vendor-prefixed/composer/installed.json')
+        );
+
+        $this->assertSame(
+            [
+                'acme/aaa-copied-parent',
+                'acme/zzz-copied-child',
+            ],
+            $packageNames
+        );
+    }
 
     /**
      * When {@see InstalledJson::cleanupVendorInstalledJson()} is run, it changes the relative paths to the packages.
@@ -204,5 +245,184 @@ EOD;
 
         $this->assertStringNotContainsString('"": "src/"', $vendorInstalledJsonStringAfter);
         $this->assertStringContainsString('"BrianHenryIE\\\\Strauss\\\\": "src/"', $vendorPrefixedInstalledJsonPsr4PhpStringAfter);
+    }
+
+    private function createDeletedParentWithExcludedDependencyFixture(): void
+    {
+        $this->writeJsonFile(
+            $this->testsWorkingDir . '/composer.json',
+            [
+                'name' => 'acme/root',
+                'version' => '1.0.0',
+                'repositories' => [
+                    $this->pathRepository('packages/deleted-parent'),
+                    $this->pathRepository('packages/ordinary-child'),
+                    $this->pathRepository('packages/preserved-files'),
+                ],
+                'require' => [
+                    'acme/deleted-parent' => '1.0.0',
+                ],
+                'extra' => [
+                    'strauss' => [
+                        'namespace_prefix' => 'Acme\\Prefixed\\',
+                        'classmap_prefix' => 'Acme_Prefixed_',
+                        'target_directory' => 'vendor-prefixed',
+                        'packages' => [
+                            'acme/deleted-parent',
+                        ],
+                        'delete_vendor_packages' => true,
+                        'optimize_autoloader' => false,
+                        'exclude_from_copy' => [
+                            'packages' => [
+                                'acme/preserved-files',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->writePackage(
+            'packages/deleted-parent',
+            'acme/deleted-parent',
+            [
+                'acme/ordinary-child' => '1.0.0',
+                'acme/preserved-files' => '1.0.0',
+            ],
+            'Acme\\DeletedParent\\',
+            'ParentThing'
+        );
+        $this->writePackage('packages/ordinary-child', 'acme/ordinary-child', [], 'Acme\\OrdinaryChild\\', 'ChildThing');
+        $this->writePackage('packages/preserved-files', 'acme/preserved-files', [], 'Acme\\Preserved\\', 'Thing');
+    }
+
+    private function createTargetPackageRemovalFixture(): void
+    {
+        $this->writeJsonFile(
+            $this->testsWorkingDir . '/composer.json',
+            [
+                'name' => 'acme/root',
+                'version' => '1.0.0',
+                'repositories' => [
+                    $this->pathRepository('packages/aaa-copied-parent'),
+                    $this->pathRepository('packages/mm-unrelated-root'),
+                    $this->pathRepository('packages/zzz-copied-child'),
+                ],
+                'require' => [
+                    'acme/aaa-copied-parent' => '1.0.0',
+                    'acme/mm-unrelated-root' => '1.0.0',
+                ],
+                'extra' => [
+                    'strauss' => [
+                        'namespace_prefix' => 'Acme\\Prefixed\\',
+                        'classmap_prefix' => 'Acme_Prefixed_',
+                        'target_directory' => 'vendor-prefixed',
+                        'packages' => [
+                            'acme/aaa-copied-parent',
+                        ],
+                        'delete_vendor_packages' => true,
+                        'optimize_autoloader' => false,
+                    ],
+                ],
+            ]
+        );
+
+        $this->writePackage(
+            'packages/aaa-copied-parent',
+            'acme/aaa-copied-parent',
+            [
+                'acme/zzz-copied-child' => '1.0.0',
+            ],
+            'Acme\\CopiedParent\\',
+            'ParentThing'
+        );
+        $this->writePackage('packages/mm-unrelated-root', 'acme/mm-unrelated-root', [], 'Acme\\UnrelatedRoot\\', 'RootThing');
+        $this->writePackage('packages/zzz-copied-child', 'acme/zzz-copied-child', [], 'Acme\\CopiedChild\\', 'ChildThing');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pathRepository(string $path): array
+    {
+        return [
+            'type' => 'path',
+            'url' => $path,
+            'options' => [
+                'symlink' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, string> $requires
+     */
+    private function writePackage(string $path, string $name, array $requires, string $namespace, string $className): void
+    {
+        $composerJson = [
+            'name' => $name,
+            'version' => '1.0.0',
+            'autoload' => [
+                'psr-4' => [
+                    $namespace => 'src/',
+                ],
+            ],
+        ];
+
+        if (!empty($requires)) {
+            $composerJson['require'] = $requires;
+        }
+
+        $this->writeJsonFile($this->testsWorkingDir . '/' . $path . '/composer.json', $composerJson);
+        $this->writeFile(
+            $this->testsWorkingDir . '/' . $path . '/src/' . $className . '.php',
+            sprintf(
+                "<?php\n\nnamespace %s;\n\nclass %s\n{\n}\n",
+                trim($namespace, '\\'),
+                $className
+            )
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $contents
+     */
+    private function writeJsonFile(string $path, array $contents): void
+    {
+        $this->writeFile(
+            $path,
+            json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL
+        );
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function assertInstalledJsonPackagesIsList(string $installedJson): array
+    {
+        $installedJsonArray = json_decode($installedJson, true);
+
+        $this->assertIsArray($installedJsonArray, 'installed.json should decode to an array');
+        $this->assertArrayHasKey('packages', $installedJsonArray, 'installed.json should contain packages');
+        $this->assertIsArray($installedJsonArray['packages']);
+        $isList = function_exists('array_is_list')
+            ? array_is_list($installedJsonArray['packages'])
+            : array_keys($installedJsonArray['packages']) === array_keys(array_values($installedJsonArray['packages']));
+        $this->assertTrue($isList, 'installed.json packages should be a JSON list');
+
+        return array_map(
+            static fn(array $package): string => $package['name'],
+            $installedJsonArray['packages']
+        );
     }
 }


### PR DESCRIPTION
# Reindex installed.json package lists before writing

## Summary

This PR keeps the `packages` key in Composer `installed.json` files encoded as a JSON list after Strauss removes package entries during cleanup.

## Problem

`InstalledJson` removes packages from `installed.json['packages']` with `unset()`. If that leaves gaps in the numeric array keys, PHP encodes the array as a JSON object rather than a JSON list.

For example, this PHP array shape:

```php
[
    'packages' => [
        1 => [
            'name' => 'acme/preserved-files',
        ],
    ],
]
```

encodes as:

```json
{
  "packages": {
    "1": {
      "name": "acme/preserved-files"
    }
  }
}
```

Composer's normal `installed.json` shape is:

```json
{
  "packages": [
    {
      "name": "acme/preserved-files"
    }
  ]
}
```

This can affect both `vendor-prefixed/composer/installed.json`, where Strauss removes packages that were not copied to the target, and `vendor/composer/installed.json`, where Strauss removes deleted vendor packages.

## Fix

Before writing either `installed.json` file, Strauss now reindexes the `packages` array with `array_values()`.

The package filtering rules are unchanged. This only preserves the expected JSON list shape before serialization.

## Tests

I added integration coverage for both affected write paths:

* target `installed.json`: a non-Strauss package is filtered out, copied packages remain, and `packages` stays a JSON list
* vendor `installed.json`: a deleted package is removed, a preserved package remains, and `packages` stays a JSON list
