### PR TITLE
Update packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "json-mapper/json-mapper": "^2.0.0",
         "league/flysystem": "^2.1|^3.0",
         "league/flysystem-memory": "*",
-        "monolog/monolog": "^2.10",
+        "monolog/monolog": "^3.10.0",
         "nikic/php-parser": "^5.4.0",
-        "symfony/console": "^4|^5|^6|^7",
-        "symfony/finder": "^4|^5|^6|^7"
+        "symfony/console": "^6|^7|^8",
+        "symfony/finder": "^6|^7|^8"
     },
     "autoload": {
         "psr-4": {
@@ -54,16 +54,15 @@
     "require-dev": {
         "php": "^7.4|^8.0",
         "brianhenryie/color-logger": "*",
-        "brianhenryie/php-codecoverage-markdown": "^0.1.0",
         "clue/phar-composer": "^1.4",
         "jaschilz/php-coverage-badger": "^2.0",
         "mockery/mockery": "^1.6",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-mockery": "^1.1",
+        "phpstan/phpstan": "^2.2.1",
+        "phpstan/phpstan-mockery": "^2.0.0",
         "phpunit/phpcov": "*",
-        "phpunit/phpunit": "^9|^10",
-        "squizlabs/php_codesniffer": "^3.5"
+        "phpunit/phpunit": "^12|^13",
+        "squizlabs/php_codesniffer": "^4.0.1"
     },
     "conflict": {
       "json-mapper/json-mapper": "2.23.0 | 2.24.0"

--- a/src/Helpers/Log/PadColonColumnsLogProcessor.php
+++ b/src/Helpers/Log/PadColonColumnsLogProcessor.php
@@ -9,24 +9,17 @@
 
 namespace BrianHenryIE\Strauss\Helpers\Log;
 
-use DateTimeInterface;
+use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 
-/**
- * @phpstan-type MonologRecordArray array{message: string, context: array<string,mixed>, level: 100|200|250|300|400|500|550|600, level_name: 'ALERT'|'CRITICAL'|'DEBUG'|'EMERGENCY'|'ERROR'|'INFO'|'NOTICE'|'WARNING', channel: string, datetime: DateTimeInterface, extra: array<mixed>}
- */
 class PadColonColumnsLogProcessor implements ProcessorInterface
 {
     /** @var int $padLength */
     protected int $padLength = 0;
 
-    /**
-     * @param MonologRecordArray $record
-     * @return MonologRecordArray
-     */
-    public function __invoke(array $record): array
+    public function __invoke(LogRecord $record): LogRecord
     {
-        $message = $record['message'];
+        $message = $record->message;
 
         $messageParts = explode(':::', $message, 2);
 
@@ -41,9 +34,7 @@ class PadColonColumnsLogProcessor implements ProcessorInterface
 
         $messageParts[0] = $this->pad($messageParts[0], $this->padLength);
 
-        $record['message'] = implode('', $messageParts);
-
-        return $record;
+        return $record->with(message: implode('', $messageParts));
     }
 
     private function pad(string $text, int $padLength): string

--- a/src/Helpers/Log/RelativeFilepathLogProcessor.php
+++ b/src/Helpers/Log/RelativeFilepathLogProcessor.php
@@ -8,6 +8,7 @@
 namespace BrianHenryIE\Strauss\Helpers\Log;
 
 use BrianHenryIE\Strauss\Helpers\FileSystem;
+use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 
 class RelativeFilepathLogProcessor implements ProcessorInterface
@@ -25,16 +26,16 @@ class RelativeFilepathLogProcessor implements ProcessorInterface
      * relative to the project root.
      *
      */
-    public function __invoke(array $record): array
+    public function __invoke(LogRecord $record): LogRecord
     {
-        $context = $record['context'];
+        $context = $record->context;
 
         foreach ($context as $key => $val) {
             if (false !== stripos($key, 'path') && is_string($val)) {
-                $record['context'][$key] = $this->fileSystem->getProjectRelativePath($val);
+                $context[$key] = $this->fileSystem->getProjectRelativePath($val);
             }
         }
 
-        return $record;
+        return $record->with(context: $context);
     }
 }

--- a/tests/Integration/Autoload/DumpAutoloadFeatureTest.php
+++ b/tests/Integration/Autoload/DumpAutoloadFeatureTest.php
@@ -13,15 +13,14 @@ use Composer\Autoload\AutoloadGenerator;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @see DumpAutoload
  */
 class DumpAutoloadFeatureTest extends IntegrationTestCase
 {
-    /**
-     * @dataProvider provider_optimize_autoloader_for_prefixed_autoload_real
-     */
+    #[DataProvider('provider_optimize_autoloader_for_prefixed_autoload_real')]
     public function test_optimize_autoloader_for_prefixed_autoload_real(string $composerJsonString, bool $expectAuthoritative): void
     {
         try {
@@ -115,8 +114,8 @@ EOD;
      * @param string $composerJsonString Contents of the composer.json file.
      * @param bool   $includeRootAutoload Whether the root autoload should be included in the vendor-prefixed autoloader.
      *
-     * @dataProvider provider_fix_double_loading_of_files_autoloaders
      */
+    #[DataProvider('provider_fix_double_loading_of_files_autoloaders')]
     public function test_fix_double_loading_of_files_autoloaders(string $composerJsonString, bool $includeRootAutoload): void
     {
         mkdir($this->testsWorkingDir . '/src');
@@ -207,8 +206,8 @@ EOD;
      * @param string $composerJsonString  Contents of the composer.json file.
      * @param bool   $expectRootAutoload  Whether autoload classes are expected in the vendor-prefixed autoloader.
      *
-     * @dataProvider provider_option_include_root_autoload
      */
+    #[DataProvider('provider_option_include_root_autoload')]
     public function test_option_include_root_autoload(string $composerJsonString, bool $expectRootAutoload): void
     {
         mkdir($this->testsWorkingDir . '/src');

--- a/tests/Integration/CleanupIntegrationTest.php
+++ b/tests/Integration/CleanupIntegrationTest.php
@@ -7,6 +7,7 @@ use BrianHenryIE\Strauss\Pipeline\Cleanup\Cleanup;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Util\Platform;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Class CleanupIntegrationTest
@@ -15,9 +16,7 @@ use Composer\Util\Platform;
  */
 class CleanupIntegrationTest extends IntegrationTestCase
 {
-    /**
-     * @dataProvider provider_optimize_autoloader_for_vendor_autoload_real
-     */
+    #[DataProvider('provider_optimize_autoloader_for_vendor_autoload_real')]
     public function test_optimize_autoloader_for_vendor_autoload_real(string $composerJsonString, bool $expectAuthoritative): void
     {
         try {

--- a/tests/Issues/MozartIssue129Test.php
+++ b/tests/Issues/MozartIssue129Test.php
@@ -17,6 +17,7 @@ use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
 use BrianHenryIE\Strauss\Pipeline\Prefixer;
 use BrianHenryIE\Strauss\TestCase;
 use BrianHenryIE\Strauss\Helpers\FileSystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 
 /**
@@ -29,9 +30,8 @@ class MozartIssue129Test extends TestCase
 
     /**
      * @author BrianHenryIE
-     *
-     * @dataProvider pairTestDataProvider
      */
+    #[DataProvider('pairTestDataProvider')]
     public function test_test($phpString, $expected)
     {
 

--- a/tests/Issues/StraussIssue183Test.php
+++ b/tests/Issues/StraussIssue183Test.php
@@ -8,6 +8,7 @@
 namespace BrianHenryIE\Strauss\Tests\Issues;
 
 use BrianHenryIE\Strauss\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @package BrianHenryIE\Strauss\Tests\Issues
@@ -24,9 +25,7 @@ class StraussIssue183Test extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @dataProvider \BrianHenryIE\Strauss\Tests\Issues\StraussIssue183Test::bootstrapDataProvider
-     */
+    #[DataProvider('bootstrapDataProvider')]
     public function test_bootstrap(string $targetDirectoryJsonLine)
     {
         $straussAbsoluteDir = dirname(__DIR__, 2);

--- a/tests/Unit/Helpers/NamespaceSortTest.php
+++ b/tests/Unit/Helpers/NamespaceSortTest.php
@@ -3,6 +3,7 @@
 namespace BrianHenryIE\Strauss\Helpers;
 
 use BrianHenryIE\Strauss\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass \BrianHenryIE\Strauss\Helpers\NamespaceSort
@@ -56,12 +57,11 @@ class NamespaceSortTest extends TestCase
     }
 
     /**
-     * @dataProvider namespaceSortDataProvider
-     *
      * @param string[] $inputs A list of namespaces to sort
      * @param bool $order Longest (false)/shortest (true))
      * @param string $expectedFirst After sorting, the first element in the array should be this
      */
+    #[DataProvider('namespaceSortDataProvider')]
     public function testNamespaceSort(array $inputs, bool $order, string $expectedFirst)
     {
 


### PR DESCRIPTION
This PR updates composer packages which should resolve some deprecations I've been seeing when using strauss.

Mainly

```bash
Deprecated: League\Flysystem\Local\LocalFilesystemAdapter::__construct(): Implicitly marking parameter $visibility as nullable is deprecated, the explicit nullable type must be used instead in phar:///.../strauss.phar/vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php on line 84

Deprecated: League\Flysystem\Local\LocalFilesystemAdapter::__construct(): Implicitly marking parameter $mimeTypeDetector as nullable is deprecated, the explicit nullable type must be used instead in phar:///.../strauss.phar/vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php on line 87

Deprecated: League\Flysystem\Filesystem::__construct(): Implicitly marking parameter $pathNormalizer as nullable is deprecated, the explicit nullable type must be used instead in phar:///.../strauss.phar/vendor/league/flysystem/src/Filesystem.php on line 24
```

I've had to remove the `brianhenryie/php-codecoverage-markdown` because I was seeing conflicts with some packages, and because it's a dev dependency I think we can live without it for the time being.

```bash
Problem 1
    - Root composer.json requires brianhenryie/php-codecoverage-markdown ^0.2.0 -> satisfiable by brianhenryie/php-codecoverage-markdown[0.2].
    - Root composer.json requires phpunit/phpunit ^12|^13 -> satisfiable by phpunit/phpunit[12.5.8, ..., 12.5.x-dev, 13.0.0, ..., 13.2.x-dev (alias of dev-main)].
    - phpunit/phpunit[12.5.8, ..., 12.5.x-dev] require phpunit/php-text-template ^5.0.0 -> satisfiable by phpunit/php-text-template[5.0.0, 5.0.x-dev].
    - phpunit/phpunit[dev-main, 13.0.0, ..., 13.2.x-dev] require sebastian/version ^7.0.0 -> satisfiable by sebastian/version[7.0.0, 7.0.x-dev].
    - Conclusion: don't install phpunit/php-text-template 5.0.0 (conflict analysis result)
    - Conclusion: don't install sebastian/version 7.0.0 (conflict analysis result)
    - phpunit/phpunit 13.2.x-dev is an alias of phpunit/phpunit dev-main and thus requires it to be installed too.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```

I've tested it locally with the project I have strauss on, and everything worked, don't see any deprecations (on PHP 8.4), and the project works, so it should be ok.

https://github.com/user-attachments/assets/0ea3bb0f-8066-4a29-8d39-ae5a37240c82


