### PR TITLE
Fix constant prefix substring collisions during replacement

### DIFF
--- a/src/Pipeline/Prefixer.php
+++ b/src/Pipeline/Prefixer.php
@@ -21,7 +21,9 @@ use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Const_;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Use_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
@@ -486,6 +488,7 @@ class Prefixer
      */
     protected function replaceConstants(string $contents, array $originalConstants, string $prefix): string
     {
+        usort($originalConstants, fn($a, $b) => strlen($b) <=> strlen($a));
 
         foreach ($originalConstants as $constant) {
             $contents = $this->replaceConstant($contents, $constant, $prefix . $constant);
@@ -496,7 +499,129 @@ class Prefixer
 
     protected function replaceConstant(string $contents, string $originalConstant, string $replacementConstant): string
     {
-        return str_replace($originalConstant, $replacementConstant, $contents);
+        if ($originalConstant === $replacementConstant) {
+            return $contents;
+        }
+
+        $needsPhpTag = !preg_match('/^\s*<\?php/', ltrim($contents));
+        $parseContents = $needsPhpTag ? "<?php\n" . $contents : $contents;
+
+        $nodeFinder = new NodeFinder();
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        try {
+            $ast = $parser->parse($parseContents);
+        } catch (\PhpParser\Error $e) {
+            $this->logger->warning("Skipping ::replaceConstant() AST replacement due to parse error: " . $e->getMessage());
+
+            return str_replace($originalConstant, $replacementConstant, $contents);
+        }
+
+        if (null === $ast) {
+            return $contents;
+        }
+
+        $positions = [];
+
+        /** @var ConstFetch[] $constFetches */
+        $constFetches = $nodeFinder->findInstanceOf($ast, ConstFetch::class);
+        foreach ($constFetches as $fetch) {
+            if (
+                $fetch->name instanceof Name
+                && !$fetch->name->isFullyQualified()
+                && $fetch->name->toString() === $originalConstant
+            ) {
+                $positions[] = [
+                    'start' => $fetch->name->getStartFilePos(),
+                    'end' => $fetch->name->getEndFilePos() + 1,
+                    'replacement' => $replacementConstant,
+                ];
+            }
+        }
+
+        /** @var Use_[] $uses */
+        $uses = $nodeFinder->findInstanceOf($ast, Use_::class);
+        foreach ($uses as $use) {
+            if (Use_::TYPE_CONSTANT !== $use->type) {
+                continue;
+            }
+
+            foreach ($use->uses as $useItem) {
+                if ($useItem->name->toString() !== $originalConstant) {
+                    continue;
+                }
+
+                $positions[] = [
+                    'start' => $useItem->name->getStartFilePos(),
+                    'end' => $useItem->name->getEndFilePos() + 1,
+                    'replacement' => $replacementConstant,
+                ];
+            }
+        }
+
+        /** @var Const_[] $constDeclarations */
+        $constDeclarations = $nodeFinder->findInstanceOf($ast, Const_::class);
+        foreach ($constDeclarations as $constDeclaration) {
+            foreach ($constDeclaration->consts as $const) {
+                if ($const->name->toString() === $originalConstant) {
+                    $positions[] = [
+                        'start' => $const->name->getStartFilePos(),
+                        'end' => $const->name->getEndFilePos() + 1,
+                        'replacement' => $replacementConstant,
+                    ];
+                }
+            }
+        }
+
+        $functionsUsingConstantName = [
+            'define',
+            'defined',
+        ];
+
+        /** @var FuncCall[] $funcCalls */
+        $funcCalls = $nodeFinder->findInstanceOf($ast, FuncCall::class);
+        foreach ($funcCalls as $call) {
+            if (
+                !$call->name instanceof Name
+                || !in_array($call->name->toString(), $functionsUsingConstantName, true)
+                || !isset($call->args[0])
+                || !$call->args[0] instanceof Arg
+                || !$call->args[0]->value instanceof String_
+            ) {
+                continue;
+            }
+
+            $stringNode = $call->args[0]->value;
+            if ($stringNode->value !== $originalConstant) {
+                continue;
+            }
+
+            $positions[] = [
+                'start' => $stringNode->getStartFilePos() + 1,
+                'end' => $stringNode->getEndFilePos(),
+                'replacement' => $replacementConstant,
+            ];
+        }
+
+        if (empty($positions)) {
+            return $contents;
+        }
+
+        usort($positions, fn($a, $b) => $b['start'] <=> $a['start']);
+
+        foreach ($positions as $pos) {
+            $parseContents = substr_replace(
+                $parseContents,
+                $pos['replacement'],
+                $pos['start'],
+                $pos['end'] - $pos['start']
+            );
+        }
+
+        if ($needsPhpTag) {
+            return substr($parseContents, strlen("<?php\n"));
+        }
+
+        return $parseContents;
     }
 
     protected function replaceFunctions(string $contents, FunctionSymbol $functionSymbol): string

--- a/src/Pipeline/Prefixer.php
+++ b/src/Pipeline/Prefixer.php
@@ -503,7 +503,7 @@ class Prefixer
             return $contents;
         }
 
-        $needsPhpTag = !preg_match('/^\s*<\?php/', ltrim($contents));
+        $needsPhpTag = false === strpos($contents, '<?php');
         $parseContents = $needsPhpTag ? "<?php\n" . $contents : $contents;
 
         $nodeFinder = new NodeFinder();
@@ -513,7 +513,11 @@ class Prefixer
         } catch (\PhpParser\Error $e) {
             $this->logger->warning("Skipping ::replaceConstant() AST replacement due to parse error: " . $e->getMessage());
 
-            return str_replace($originalConstant, $replacementConstant, $contents);
+            return preg_replace(
+                '/\b' . preg_quote($originalConstant, '/') . '\b/',
+                $replacementConstant,
+                $contents
+            );
         }
 
         if (null === $ast) {
@@ -527,13 +531,15 @@ class Prefixer
         foreach ($constFetches as $fetch) {
             if (
                 $fetch->name instanceof Name
-                && !$fetch->name->isFullyQualified()
+                && (!$fetch->name->isFullyQualified() || 1 === count($fetch->name->getParts()))
                 && $fetch->name->toString() === $originalConstant
             ) {
                 $positions[] = [
                     'start' => $fetch->name->getStartFilePos(),
                     'end' => $fetch->name->getEndFilePos() + 1,
-                    'replacement' => $replacementConstant,
+                    'replacement' => $fetch->name->isFullyQualified()
+                        ? '\\' . $replacementConstant
+                        : $replacementConstant,
                 ];
             }
         }

--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -869,6 +869,43 @@ EOD;
         self::assertStringContainsString("define('BHMP_ANOTHER_CONSTANT', '1.83');", $result);
     }
 
+    /**
+     * Prefixing a shorter constant name must not corrupt longer constant names that share a prefix.
+     */
+    public function testReplaceConstantDoesNotCorruptPrefixSupersetConstant(): void
+    {
+        $contents = <<<'EOD'
+<?php
+if (!defined('FILTER_VALIDATE_BOOL') && defined('FILTER_VALIDATE_BOOLEAN')) {
+    define('FILTER_VALIDATE_BOOL', \FILTER_VALIDATE_BOOLEAN);
+}
+use const FILTER_VALIDATE_BOOL;
+
+$enabled = filter_var($input, FILTER_VALIDATE_BOOL);
+$other = filter_var($input, FILTER_VALIDATE_BOOLEAN);
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+        $config->method('getConstantsPrefix')->willReturn('PREFIX_');
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $file = Mockery::mock(File::class);
+        $file->shouldReceive('addDiscoveredSymbol');
+        $file->shouldReceive('getSourcePath');
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $constant = new ConstantSymbol('FILTER_VALIDATE_BOOL', $file);
+        $discoveredSymbols->add($constant);
+
+        $result = $replacer->replaceInString($discoveredSymbols, $contents);
+
+        self::assertStringContainsString("define('PREFIX_FILTER_VALIDATE_BOOL', \\FILTER_VALIDATE_BOOLEAN);", $result);
+        self::assertStringContainsString('use const PREFIX_FILTER_VALIDATE_BOOL;', $result);
+        self::assertStringContainsString('filter_var($input, PREFIX_FILTER_VALIDATE_BOOL)', $result);
+        self::assertStringContainsString('filter_var($input, FILTER_VALIDATE_BOOLEAN)', $result);
+        self::assertStringNotContainsString('PREFIX_FILTER_VALIDATE_BOOLEAN', $result);
+    }
+
     public function testStaticFunctionCallOfNamespacedClassIsPrefixed(): void
     {
 

--- a/tests/Unit/PrefixerTest.php
+++ b/tests/Unit/PrefixerTest.php
@@ -906,6 +906,83 @@ EOD;
         self::assertStringNotContainsString('PREFIX_FILTER_VALIDATE_BOOLEAN', $result);
     }
 
+    public function testReplaceConstantsWithLeadingCommentBeforePhpTag(): void
+    {
+        $contents = <<<'EOD'
+/*******************************************************************************
+ * License header
+ ******************************************************************************/
+
+<?php
+
+define('MY_CONSTANT', 'value');
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+        $config->method('getConstantsPrefix')->willReturn('PREFIX_');
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $file = Mockery::mock(File::class);
+        $file->shouldReceive('addDiscoveredSymbol');
+        $file->shouldReceive('getSourcePath');
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $discoveredSymbols->add(new ConstantSymbol('MY_CONSTANT', $file));
+
+        $result = $replacer->replaceInString($discoveredSymbols, $contents);
+
+        self::assertStringContainsString("define('PREFIX_MY_CONSTANT', 'value');", $result);
+        self::assertStringNotContainsString("<?php\n<?php", $result);
+    }
+
+    public function testReplaceConstantFallbackDoesNotCorruptPrefixSupersetConstant(): void
+    {
+        $contents = 'FILTER_VALIDATE_BOOLEAN; FILTER_VALIDATE_BOOL;';
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $method = new \ReflectionMethod(Prefixer::class, 'replaceConstant');
+        $method->setAccessible(true);
+        $result = $method->invoke(
+            $replacer,
+            $contents,
+            'FILTER_VALIDATE_BOOL',
+            'PREFIX_FILTER_VALIDATE_BOOL'
+        );
+
+        self::assertSame(
+            'FILTER_VALIDATE_BOOLEAN; PREFIX_FILTER_VALIDATE_BOOL;',
+            $result
+        );
+    }
+
+    public function testReplaceConstantPrefixesFullyQualifiedGlobalConstant(): void
+    {
+        $contents = <<<'EOD'
+<?php
+define('MY_CONSTANT', 1);
+$value = \MY_CONSTANT;
+EOD;
+
+        $config = $this->createMock(PrefixerConfigInterface::class);
+        $config->method('getConstantsPrefix')->willReturn('PREFIX_');
+        $replacer = new Prefixer($config, $this->getInMemoryFileSystem());
+
+        $file = Mockery::mock(File::class);
+        $file->shouldReceive('addDiscoveredSymbol');
+        $file->shouldReceive('getSourcePath');
+
+        $discoveredSymbols = new DiscoveredSymbols();
+        $discoveredSymbols->add(new ConstantSymbol('MY_CONSTANT', $file));
+
+        $result = $replacer->replaceInString($discoveredSymbols, $contents);
+
+        self::assertStringContainsString("define('PREFIX_MY_CONSTANT', 1);", $result);
+        self::assertStringContainsString('$value = \\PREFIX_MY_CONSTANT;', $result);
+        self::assertStringNotContainsString('\\MY_CONSTANT', $result);
+    }
+
     public function testStaticFunctionCallOfNamespacedClassIsPrefixed(): void
     {
 


### PR DESCRIPTION
Hey, @BrianHenryIE - this is an AI assisted commit just so you know up front. We were looking to make sure any constants to be excluded as defined in exclude_constants were treated as exact matches and not the substring prefixes of other constants which might start with the same substring. More details below!

## Problem

Strauss rewrites constants using naive `str_replace()` in `Prefixer::replaceConstant()`. When a shorter constant name is a prefix of a longer one, prefixing the shorter name corrupts the longer name even when the longer name is listed in `exclude_constants` (or is a PHP built-in that Strauss never discovers as a symbol).

**Example:** Symfony's `polyfill-php80` defines `FILTER_VALIDATE_BOOL`. Prefixing that constant also corrupts uses of `FILTER_VALIDATE_BOOLEAN` because `FILTER_VALIDATE_BOOLEAN` contains the substring `FILTER_VALIDATE_BOOL`.

## Solution

Replace constant rewriting with AST-aware updates for:

- `ConstFetch`
- `use const` imports
- `define()` / `defined()` calls
- `const` declarations

Fall back to `str_replace()` only when PHP parsing fails. When multiple constants are replaced in one file, sort longest-first to reduce edge cases in the fallback path.

## Test plan

- [x] Added `PrefixerTest::testReplaceConstantDoesNotCorruptPrefixSupersetConstant` (FILTER_VALIDATE_BOOL / FILTER_VALIDATE_BOOLEAN case)
- [x] Full `PrefixerTest` suite passes (81 tests)

## Notes

We've been running this on a fork release ([AndrewJDawes/strauss `0.27.3-andrewjdawes.1`](https://github.com/AndrewJDawes/strauss/releases/tag/0.27.3-andrewjdawes.1)) while consuming Strauss from a WordPress plugin build. Happy to adjust approach, naming, or test coverage based on your preferences.

Made with [Cursor](https://cursor.com)