### PR TITLE
Skip .git, .gitignore and .gitattributes export-ignore files when enumerating

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Strauss potentially requires zero configuration, but likely you'll want to custo
         "namespace_replacement_patterns" : {
         },
         "delete_vendor_packages": false,
-        "delete_vendor_files": false
+        "delete_vendor_files": false,
+        "exclude_git_files": true
     }
 },
 ```
@@ -205,6 +206,7 @@ The following configuration is default:
 - `update_call_sites`: `false`. This can be `true`, `false` or an `array` of directories/filepaths. When set to `true` it defaults to the directories and files in the project's `autoload` key. The PHP files and directories' PHP files will be updated where they call the prefixed classes.
 - `include_root_autoload`: `false` is a boolean flag to indicate whether Strauss should include the root autoload section of your project when creating its autoloader. It is false by default. Enabling this option will allow you to require only the Strauss autoloader in your project. Note that conflicts may occur if your project enables this option, requires both the Composer and Strauss autoloaders, and uses `files` autoloading.
 - `optimize_autoloader`: `true` is a boolean flag to indicate whether Strauss should force optimized/classmap-authoritative autoload generation. Set it to `false` to still regenerate autoload files without authoritative mode.
+- `exclude_git_files`: `true` is a boolean flag to indicate whether Strauss should skip files that would not be part of a package's distributed archive when enumerating files to copy: the `.git` directory, files matched by the package's `.gitignore`, and files marked `export-ignore` in the package's `.gitattributes` (mirroring `git archive` / Composer dist behaviour). Set it to `false` to copy every file found in the package directory. This is mostly useful for symlinked packages during local development.
 
 To disable optimized/classmap-authoritative Composer autoload generation:
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "composer/class-map-generator": "^1.6.0",
         "composer/composer": "^2.10",
         "elazar/flystream": "^0.6.0 || ^1.4.0",
+        "inmarelibero/gitignore-checker": "^1.0",
         "json-mapper/json-mapper": "^2.0.0",
         "league/flysystem": "^2.5.0 || ^3.33.0",
         "league/flysystem-memory": "*",

--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -209,6 +209,12 @@ class StraussConfig implements
     protected bool $optimizeAutoloader = true;
 
     /**
+     * Should `.git`, `.gitignore`-matched and `.gitattributes export-ignore` files be skipped when
+     * enumerating each package's files (mimicking `git archive` / Composer dist behaviour)?
+     */
+    protected bool $excludeGitFiles = true;
+
+    /**
      * Read any existing Mozart config.
      * Overwrite it with any Strauss config.
      * Provide sensible defaults.
@@ -698,6 +704,22 @@ class StraussConfig implements
     public function setDeleteVendorPackages(bool $deleteVendorPackages): void
     {
         $this->deleteVendorPackages = $deleteVendorPackages;
+    }
+
+    /**
+     * Should exclude `.git` directory and read and follow `.gitignore` and `.gitattributes` files. Mostly relevant for local symlinked packages.
+     */
+    public function getExcludeGitFiles(): bool
+    {
+        return $this->excludeGitFiles;
+    }
+
+    /**
+     * Should Strauss read and respect `.gitignore` and `.gitattributes` files and exclude `.git` directory. Packagist packages have already respected these.
+     */
+    public function setExcludeGitFiles(bool $excludeGitFiles): void
+    {
+        $this->excludeGitFiles = $excludeGitFiles;
     }
 
     /**

--- a/src/Config/FileEnumeratorConfig.php
+++ b/src/Config/FileEnumeratorConfig.php
@@ -19,4 +19,10 @@ interface FileEnumeratorConfig
 
     /** @return string[] */
     public function getExcludeFilePatternsFromCopy(): array;
+
+    /**
+     * Whether to skip `.git`, `.gitignore`-matched and `.gitattributes`.`[].export-ignore` files when
+     * enumerating each package's files.
+     */
+    public function getExcludeGitFiles(): bool;
 }

--- a/src/Helpers/GitAttributes.php
+++ b/src/Helpers/GitAttributes.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Minimal `.gitattributes` parser, used to determine which files a package marks `export-ignore`
+ * (i.e. files `git archive` / Composer dist would strip from the distributed package).
+ *
+ * Only the subset of `.gitattributes` needed by Strauss is implemented: line parsing into
+ * pattern + attributes, and `export-ignore` path matching using gitignore-style globbing.
+ *
+ * @author Claude
+ *
+ * @package brianhenryie/strauss
+ */
+
+namespace BrianHenryIE\Strauss\Helpers;
+
+use League\Flysystem\FilesystemException;
+
+class GitAttributes
+{
+    protected FileSystem $filesystem;
+
+    protected string $repositoryPath;
+
+    protected string $gitAttributesFilename;
+
+    /**
+     * @var ?array<array{pattern:string, attributes:array<string, bool|string|null>}>
+     */
+    protected ?array $parsed = null;
+
+    public function __construct(
+        FileSystem $filesystem,
+        string $repositoryPath,
+        string $gitAttributesFilename = '.gitattributes'
+    ) {
+        $this->filesystem = $filesystem;
+        $this->repositoryPath = rtrim(FileSystem::normalizeDirSeparator($repositoryPath), '/');
+        $this->gitAttributesFilename = $gitAttributesFilename;
+    }
+
+    /**
+     * Read and parse the repository's `.gitattributes` file.
+     *
+     * Each returned entry is the pattern and its attributes, where an attribute is:
+     *  - `true`   for a set attribute, e.g. `export-ignore`
+     *  - `false`  for an unset attribute, e.g. `-export-ignore`
+     *  - `null`   for an unspecified attribute, e.g. `!export-ignore`
+     *  - `string` for a valued attribute, e.g. `eol=lf`
+     *
+     * @return array<array{pattern:string, attributes:array<string, bool|string|null>}>
+     * @throws FilesystemException
+     */
+    public function parse(): array
+    {
+        if ($this->parsed !== null) {
+            return $this->parsed;
+        }
+
+        $this->parsed = [];
+
+        $gitAttributesPath = $this->repositoryPath . '/' . $this->gitAttributesFilename;
+
+        if (!$this->filesystem->fileExists($gitAttributesPath)) {
+            return $this->parsed;
+        }
+
+        $contents = $this->filesystem->read($gitAttributesPath);
+
+        foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+            $line = trim($line);
+
+            // Skip blank lines and comments.
+            if ($line === '' || strpos($line, '#') === 0) {
+                continue;
+            }
+
+            $tokens = preg_split('/\s+/', $line) ?: [];
+            $pattern = array_shift($tokens);
+
+            if ($pattern === null || $pattern === '') {
+                continue;
+            }
+
+            $attributes = [];
+            foreach ($tokens as $token) {
+                if (strpos($token, '-') === 0) {
+                    $attributes[substr($token, 1)] = false;
+                } elseif (strpos($token, '!') === 0) {
+                    $attributes[substr($token, 1)] = null;
+                } elseif (strpos($token, '=') !== false) {
+                    [$name, $value] = explode('=', $token, 2);
+                    $attributes[$name] = $value;
+                } else {
+                    $attributes[$token] = true;
+                }
+            }
+
+            $this->parsed[] = [
+                'pattern' => $pattern,
+                'attributes' => $attributes,
+            ];
+        }
+
+        return $this->parsed;
+    }
+
+    /**
+     * Whether the given repository-relative path is marked `export-ignore`.
+     *
+     * The last matching pattern wins, so a later `-export-ignore` rule can re-include a path.
+     *
+     * @throws FilesystemException
+     */
+    public function isExportIgnored(string $relativePath): bool
+    {
+        $relativePath = ltrim(FileSystem::normalizeDirSeparator($relativePath), '/');
+
+        $ignored = false;
+
+        foreach ($this->parse() as $entry) {
+            if (!array_key_exists('export-ignore', $entry['attributes'])) {
+                continue;
+            }
+
+            if ($this->matchesPattern($entry['pattern'], $relativePath)) {
+                $ignored = $entry['attributes']['export-ignore'] === true;
+            }
+        }
+
+        return $ignored;
+    }
+
+    /**
+     * Match a `.gitattributes`/`.gitignore`-style pattern against a repository-relative file path.
+     *
+     * A pattern matches when it matches the path itself or one of its ancestor directories
+     * (marking a directory `export-ignore` also excludes its contents).
+     */
+    protected function matchesPattern(string $pattern, string $relativePath): bool
+    {
+        $pattern = rtrim(FileSystem::normalizeDirSeparator($pattern), '/');
+        // A pattern containing a slash (other than a trailing one) is anchored to the repository root.
+        $isAnchored = strpos($pattern, '/') !== false;
+        $pattern = ltrim($pattern, '/');
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        if (!$isAnchored) {
+            // An unanchored pattern matches any single path segment, e.g. `tests` or `*.dist`.
+            foreach (explode('/', $relativePath) as $segment) {
+                if (fnmatch($pattern, $segment)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (fnmatch($pattern, $relativePath, FNM_PATHNAME)) {
+            return true;
+        }
+
+        // Match against each ancestor directory so a directory pattern covers the files within it.
+        $segments = explode('/', $relativePath);
+        array_pop($segments);
+
+        $ancestor = '';
+        foreach ($segments as $segment) {
+            $ancestor = $ancestor === '' ? $segment : $ancestor . '/' . $segment;
+            if (fnmatch($pattern, $ancestor, FNM_PATHNAME)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -11,6 +11,9 @@ use BrianHenryIE\Strauss\Files\DiscoveredFiles;
 use BrianHenryIE\Strauss\Files\File;
 use BrianHenryIE\Strauss\Files\FileWithDependency;
 use BrianHenryIE\Strauss\Helpers\FileSystem;
+use BrianHenryIE\Strauss\Helpers\GitAttributes;
+use Inmarelibero\GitIgnoreChecker\Exception\GitIgnoreCherkerException;
+use Inmarelibero\GitIgnoreChecker\GitIgnoreChecker;
 use League\Flysystem\FilesystemException;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -67,12 +70,115 @@ class FileEnumerator
     {
         $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths($paths);
 
+        if ($this->config->getExcludeGitFiles()) {
+            $absoluteFilePaths = $this->excludeGitFiles($paths, $absoluteFilePaths);
+        }
+
         foreach ($absoluteFilePaths as $sourceAbsolutePath) {
             $this->addFile($sourceAbsolutePath, $dependency);
         }
 
         $this->discoveredFiles->sort();
         return $this->discoveredFiles;
+    }
+
+    /**
+     * Remove files which Git would not include in the package's distributed archive:
+     * the `.git` directory, files matched by `.gitignore`, and files marked `export-ignore`
+     * in `.gitattributes`. Each base path is treated as its own repository root.
+     *
+     * @param string[] $basePaths
+     * @param string[] $absoluteFilePaths
+     *
+     * @return string[]
+     * @throws FilesystemException
+     */
+    protected function excludeGitFiles(array $basePaths, array $absoluteFilePaths): array
+    {
+        /** @var array<string, array{gitignore?:GitIgnoreChecker, gitattributes?:GitAttributes}> $repositories */
+        $repositories = [];
+        foreach ($basePaths as $basePath) {
+            if (!$this->filesystem->directoryExists($basePath)) {
+                continue;
+            }
+
+            $normalizedBasePath = rtrim(FileSystem::normalizeDirSeparator($basePath), '/');
+
+            if ($this->filesystem->fileExists($normalizedBasePath . '/.gitignore')) {
+                try {
+                    /**
+                     * TODO: use {@see FileSystem::prefixPath()} when #278 is merged.
+                     */
+                    $gitIgnoreChecker = new GitIgnoreChecker('/' . $normalizedBasePath);
+                    $repositories[$normalizedBasePath][ 'gitignore'] = $gitIgnoreChecker;
+                } catch (GitIgnoreCherkerException $e) {
+                    // e.g. when the path is not on the local filesystem (in-memory tests).
+                    $this->logger->debug("Could not read .gitignore at {path}: {message}", [
+                        'path' => $normalizedBasePath,
+                        'message' => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            if ($this->filesystem->fileExists($normalizedBasePath . '/.gitattributes')) {
+                $repositories[$normalizedBasePath][ 'gitattributes'] = new GitAttributes($this->filesystem, $normalizedBasePath);
+            }
+        }
+
+        if (empty($repositories)) {
+            return $absoluteFilePaths;
+        }
+
+        $this->logger->info('Processing .gitignore/.gitattributes – checking ' . count($absoluteFilePaths) . ' files.');
+
+        return array_values(array_filter(
+            $absoluteFilePaths,
+            fn(string $sourceAbsolutePath): bool => !$this->isGitExcluded($sourceAbsolutePath, $repositories)
+        ));
+    }
+
+    /**
+     * @param array<string, array{gitignore?:GitIgnoreChecker, gitattributes?:GitAttributes}> $repositories
+     *
+     * @throws FilesystemException
+     */
+    protected function isGitExcluded(string $sourceAbsolutePath, array $repositories): bool
+    {
+        foreach ($repositories as $basePath => $checkers) {
+            $relativePath = $this->filesystem->getRelativePath($basePath, $sourceAbsolutePath);
+
+            // Not located within this repository root.
+            if ($relativePath === '' || strpos($relativePath, '../') === 0) {
+                continue;
+            }
+
+            // The .git directory is never part of the distributed package.
+            if ($relativePath === '.git' || strpos($relativePath, '.git/') === 0) {
+                $this->logger->debug("Skipping .git file {path}", ['path' => $sourceAbsolutePath]);
+                return true;
+            }
+
+            if (isset($checkers['gitignore'])) {
+                try {
+                    if ($checkers['gitignore']->isPathIgnored('/' . $relativePath)) {
+                        $this->logger->debug("Skipping .gitignore'd file {path}", ['path' => $sourceAbsolutePath]);
+                        return true;
+                    }
+                } catch (GitIgnoreCherkerException $e) {
+                    $this->logger->debug("Could not check .gitignore for {path}: {message}", [
+                        'path' => $sourceAbsolutePath,
+                        'message' => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            if (isset($checkers['gitattributes']) && $checkers['gitattributes']->isExportIgnored($relativePath)) {
+                $this->logger->debug("Skipping export-ignore file {path}", ['path' => $sourceAbsolutePath]);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Integration/FileEnumeratorIntegrationTest.php
+++ b/tests/Integration/FileEnumeratorIntegrationTest.php
@@ -60,6 +60,7 @@ EOD;
 
         $config = $this->createStub(StraussConfig::class);
         $config->method('getAbsoluteVendorDirectory')->willReturn($vendorDir);
+        $config->method('getExcludeGitFiles')->willReturn(false);
 
         $fileEnumerator = new FileEnumerator(
             $config,

--- a/tests/Integration/Pipeline/GitFilesFeatureTest.php
+++ b/tests/Integration/Pipeline/GitFilesFeatureTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Tests\Integration\Pipeline;
+
+use BrianHenryIE\Strauss\Composer\Extra\StraussConfig;
+use BrianHenryIE\Strauss\Files\DiscoveredFiles;
+use BrianHenryIE\Strauss\IntegrationTestCase;
+use BrianHenryIE\Strauss\Pipeline\FileEnumerator;
+
+/**
+ * Verifies that FileEnumerator skips `.git`, `.gitignore`-matched and `.gitattributes export-ignore`
+ * files, and that the behaviour can be disabled via the `exclude_git_files` config flag.
+ *
+ * @coversNothing
+ */
+class GitFilesFeatureTest extends IntegrationTestCase
+{
+    /**
+     * Create a package directory on disk with files that should be kept and files that Git would
+     * exclude from the distributed archive.
+     *
+     * @return string The absolute path to the package directory.
+     */
+    private function createTestPackage(): string
+    {
+        $packageDir = $this->testsWorkingDir . '/package';
+        $filesystem = $this->getFileSystem();
+
+        // Files which should be copied.
+        $filesystem->write($packageDir . '/src/Real.php', '<?php // keep');
+        $filesystem->write($packageDir . '/README.md', '# Keep');
+
+        // `.git` internals.
+        $filesystem->write($packageDir . '/.git/config', '[core]');
+
+        // `.gitignore`-matched files.
+        $filesystem->write($packageDir . '/.gitignore', "build/\n*.log\n");
+        $filesystem->write($packageDir . '/build/generated.php', '<?php // ignored');
+        $filesystem->write($packageDir . '/debug.log', 'ignored');
+
+        // `.gitattributes export-ignore` files.
+        $filesystem->write($packageDir . '/.gitattributes', "/tests export-ignore\nphpunit.xml export-ignore\n");
+        $filesystem->write($packageDir . '/tests/RealTest.php', '<?php // export-ignored');
+        $filesystem->write($packageDir . '/phpunit.xml', '<phpunit/>');
+
+        return $packageDir;
+    }
+
+    /**
+     * @param DiscoveredFiles $files
+     * @return string[] The discovered files' source paths.
+     */
+    private function getSourcePaths(DiscoveredFiles $files): array
+    {
+        return array_map(
+            fn($file): string => $file->getSourcePath(),
+            $files->getFiles()
+        );
+    }
+
+    private function assertDiscoveredContains(DiscoveredFiles $files, string $relativePath): void
+    {
+        foreach ($this->getSourcePaths($files) as $sourcePath) {
+            if (substr($sourcePath, -strlen($relativePath)) === $relativePath) {
+                $this->addToAssertionCount(1);
+                return;
+            }
+        }
+        $this->fail($relativePath . ' should have been discovered. Found: ' . implode(', ', $this->getSourcePaths($files)));
+    }
+
+    private function assertDiscoveredNotContains(DiscoveredFiles $files, string $relativePath): void
+    {
+        foreach ($this->getSourcePaths($files) as $sourcePath) {
+            if (substr($sourcePath, -strlen($relativePath)) === $relativePath) {
+                $this->fail($relativePath . ' should not have been discovered. Found: ' . implode(', ', $this->getSourcePaths($files)));
+            }
+        }
+        $this->addToAssertionCount(1);
+    }
+
+    private function createConfig(bool $excludeGitFiles): StraussConfig
+    {
+        $config = $this->createStub(StraussConfig::class);
+        $config->method('getExcludeGitFiles')->willReturn($excludeGitFiles);
+        $config->method('getAbsoluteVendorDirectory')->willReturn($this->testsWorkingDir);
+        $config->method('getAbsoluteTargetDirectory')->willReturn($this->testsWorkingDir . '/vendor-prefixed');
+        return $config;
+    }
+
+    public function test_git_files_are_excluded_by_default(): void
+    {
+        $packageDir = $this->createTestPackage();
+
+        $fileEnumerator = new FileEnumerator(
+            $this->createConfig(true),
+            $this->getFileSystem(),
+            $this->getLogger()
+        );
+
+        $files = $fileEnumerator->compileFileListForPaths([$packageDir]);
+
+        // Kept.
+        $this->assertDiscoveredContains($files, 'package/src/Real.php');
+        $this->assertDiscoveredContains($files, 'package/README.md');
+
+        // Excluded.
+        $this->assertDiscoveredNotContains($files, '.git/config');
+        $this->assertDiscoveredNotContains($files, 'build/generated.php');
+        $this->assertDiscoveredNotContains($files, 'debug.log');
+        $this->assertDiscoveredNotContains($files, 'tests/RealTest.php');
+        $this->assertDiscoveredNotContains($files, 'phpunit.xml');
+    }
+
+    public function test_git_files_are_included_when_flag_disabled(): void
+    {
+        $packageDir = $this->createTestPackage();
+
+        $fileEnumerator = new FileEnumerator(
+            $this->createConfig(false),
+            $this->getFileSystem(),
+            $this->getLogger()
+        );
+
+        $files = $fileEnumerator->compileFileListForPaths([$packageDir]);
+
+        // With the flag disabled, every file is discovered (current/legacy behaviour).
+        $this->assertDiscoveredContains($files, 'package/src/Real.php');
+        $this->assertDiscoveredContains($files, '.git/config');
+        $this->assertDiscoveredContains($files, 'build/generated.php');
+        $this->assertDiscoveredContains($files, 'debug.log');
+        $this->assertDiscoveredContains($files, 'tests/RealTest.php');
+        $this->assertDiscoveredContains($files, 'phpunit.xml');
+    }
+}

--- a/tests/Unit/Composer/Extra/StraussConfigTest.php
+++ b/tests/Unit/Composer/Extra/StraussConfigTest.php
@@ -1086,4 +1086,49 @@ EOD;
             unlink($tmpfname);
         }
     }
+
+    public function test_exclude_git_files_default_true(): void
+    {
+        $composerExtraStraussJson = <<<'EOD'
+{
+ "extra":{
+  "strauss": {
+   "namespace_prefix": "BrianHenryIE\\Strauss\\"
+  }
+ }
+}
+EOD;
+        $tmpfname = tempnam(sys_get_temp_dir(), 'strauss-test-');
+        try {
+            file_put_contents($tmpfname, $composerExtraStraussJson);
+            $composer = Factory::create(new NullIO(), $tmpfname);
+            $sut = new StraussConfig($composer);
+            $this->assertTrue($sut->getExcludeGitFiles());
+        } finally {
+            unlink($tmpfname);
+        }
+    }
+
+    public function test_exclude_git_files_false(): void
+    {
+        $composerExtraStraussJson = <<<'EOD'
+{
+ "extra":{
+  "strauss": {
+   "namespace_prefix": "BrianHenryIE\\Strauss\\",
+   "exclude_git_files": false
+  }
+ }
+}
+EOD;
+        $tmpfname = tempnam(sys_get_temp_dir(), 'strauss-test-');
+        try {
+            file_put_contents($tmpfname, $composerExtraStraussJson);
+            $composer = Factory::create(new NullIO(), $tmpfname);
+            $sut = new StraussConfig($composer);
+            $this->assertFalse($sut->getExcludeGitFiles());
+        } finally {
+            unlink($tmpfname);
+        }
+    }
 }

--- a/tests/Unit/FileEnumeratorTest.php
+++ b/tests/Unit/FileEnumeratorTest.php
@@ -28,6 +28,7 @@ class FileEnumeratorTest extends TestCase
     public function test_file_does_not_exist(): void
     {
         $config = Mockery::mock(FileEnumeratorConfig::class);
+        $config->allows('getExcludeGitFiles')->andReturnFalse();
         $filesystem = $this->getInMemoryFileSystem();
         $logger = $this->getLogger();
 

--- a/tests/Unit/Helpers/GitAttributesTest.php
+++ b/tests/Unit/Helpers/GitAttributesTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Helpers;
+
+use BrianHenryIE\Strauss\TestCase;
+
+/**
+ * @coversDefaultClass \BrianHenryIE\Strauss\Helpers\GitAttributes
+ */
+class GitAttributesTest extends TestCase
+{
+    /**
+     * @covers ::parse
+     */
+    public function test_parse_returns_patterns_and_attributes(): void
+    {
+        $gitAttributes = <<<'EOD'
+# A comment line which should be ignored.
+
+/tests       export-ignore
+phpunit.xml  export-ignore
+*.dist       export-ignore
+src/Keep.php -export-ignore
+* text=auto
+EOD;
+
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->write('mem://package/.gitattributes', $gitAttributes);
+
+        $sut = new GitAttributes($filesystem, 'mem://package');
+
+        $parsed = $sut->parse();
+
+        $expected = [
+            ['pattern' => '/tests', 'attributes' => ['export-ignore' => true]],
+            ['pattern' => 'phpunit.xml', 'attributes' => ['export-ignore' => true]],
+            ['pattern' => '*.dist', 'attributes' => ['export-ignore' => true]],
+            ['pattern' => 'src/Keep.php', 'attributes' => ['export-ignore' => false]],
+            ['pattern' => '*', 'attributes' => ['text' => 'auto']],
+        ];
+
+        $this->assertEquals($expected, $parsed);
+    }
+
+    /**
+     * @covers ::parse
+     */
+    public function test_parse_returns_empty_array_when_no_gitattributes_file(): void
+    {
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->write('mem://package/src/Foo.php', '<?php');
+
+        $sut = new GitAttributes($filesystem, 'mem://package');
+
+        $this->assertSame([], $sut->parse());
+    }
+
+    /**
+     * @covers ::isExportIgnored
+     */
+    public function test_is_export_ignored_matches_directories_files_and_wildcards(): void
+    {
+        $gitAttributes = <<<'EOD'
+/tests      export-ignore
+phpunit.xml export-ignore
+*.dist      export-ignore
+EOD;
+
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->write('mem://package/.gitattributes', $gitAttributes);
+
+        $sut = new GitAttributes($filesystem, 'mem://package');
+
+        // Directory pattern excludes its contents.
+        $this->assertTrue($sut->isExportIgnored('tests/Unit/FooTest.php'));
+        // Exact file match.
+        $this->assertTrue($sut->isExportIgnored('phpunit.xml'));
+        // Wildcard match at any depth.
+        $this->assertTrue($sut->isExportIgnored('config/services.dist'));
+
+        // Files that should be kept.
+        $this->assertFalse($sut->isExportIgnored('src/Foo.php'));
+        $this->assertFalse($sut->isExportIgnored('README.md'));
+    }
+
+    /**
+     * @covers ::isExportIgnored
+     */
+    public function test_is_export_ignored_later_unset_reincludes_path(): void
+    {
+        $gitAttributes = <<<'EOD'
+/tests           export-ignore
+/tests/Keep.php  -export-ignore
+EOD;
+
+        $filesystem = $this->getInMemoryFileSystem();
+        $filesystem->write('mem://package/.gitattributes', $gitAttributes);
+
+        $sut = new GitAttributes($filesystem, 'mem://package');
+
+        $this->assertTrue($sut->isExportIgnored('tests/Removed.php'));
+        $this->assertFalse($sut->isExportIgnored('tests/Keep.php'));
+    }
+}


### PR DESCRIPTION
Fixes #254

## Summary

When a package is installed from source (a git clone) rather than a dist zip, `FileEnumerator` previously copied **every** file in the package directory — including `.git/` internals, build/test artifacts listed in `.gitignore`, and files the package author marked `export-ignore` in `.gitattributes` (which `git archive` / Composer dist would have stripped).

This change makes `FileEnumerator` mimic `git archive` / dist behaviour, **per package root**:

- skips the `.git` directory;
- skips files matched by the package's `.gitignore`, using [`inmarelibero/gitignore-checker`](https://packagist.org/packages/inmarelibero/gitignore-checker);
- skips files marked `export-ignore` in the package's `.gitattributes`, via a new `BrianHenryIE\Strauss\Helpers\GitAttributes` parser (`parse()` + `isExportIgnored()`).

Filtering is gated behind a new `exclude_git_files` config option which **defaults to `true`**; set it to `false` to restore the previous copy-everything behaviour.

## Changes

- `composer.json` — added `inmarelibero/gitignore-checker`.
- `src/Helpers/GitAttributes.php` (new) — minimal `.gitattributes` parser + gitignore-style path matching (anchored vs unanchored, directory-prefix matching, `*` wildcards, last-match-wins so `-export-ignore` can re-include).
- `src/Config/FileEnumeratorConfig.php` + `src/Composer/Extra/StraussConfig.php` — new `getExcludeGitFiles()` / `exclude_git_files` option (default `true`).
- `src/Pipeline/FileEnumerator.php` — builds the gitignore/gitattributes checkers once per base path and filters discovered files; degrades gracefully (try/catch) when the gitignore library cannot read a path.
- `README.md` — documented the new option.

## Tests

- **Unit** `GitAttributesTest` — parsing and export-ignore matching against the in-memory filesystem.
- **Unit** `StraussConfigTest` — `exclude_git_files` default-`true` and `false` mapping.
- **Integration** `GitFilesFeatureTest` — builds a real package dir with `.git/`, `.gitignore` and `.gitattributes` and asserts the right files are kept/skipped, plus a flag-off case proving backward compatibility.

## Verification

- `phpcs` (PSR-2): clean on all new/changed code.
- `phpstan` (level 7): no errors on all new `src` code.
- New unit + integration tests pass; full Unit suite and existing `FileEnumeratorIntegrationTest` pass.

> Note: `inmarelibero/gitignore-checker` reads the real filesystem (not the Flysystem abstraction), so `.gitignore` filtering is exercised via integration tests rather than in-memory unit tests; it degrades gracefully on non-local paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)