### PR TITLE
Performance: improve compiling file list for paths/git

### DIFF
--- a/src/Composer/Extra/StraussConfig.php
+++ b/src/Composer/Extra/StraussConfig.php
@@ -709,7 +709,7 @@ class StraussConfig implements
     /**
      * Should exclude `.git` directory and read and follow `.gitignore` and `.gitattributes` files. Mostly relevant for local symlinked packages.
      */
-    public function getExcludeGitFiles(): bool
+    public function isExcludeGitFiles(): bool
     {
         return $this->excludeGitFiles;
     }

--- a/src/Config/FileEnumeratorConfig.php
+++ b/src/Config/FileEnumeratorConfig.php
@@ -24,5 +24,5 @@ interface FileEnumeratorConfig
      * Whether to skip `.git`, `.gitignore`-matched and `.gitattributes`.`[].export-ignore` files when
      * enumerating each package's files.
      */
-    public function getExcludeGitFiles(): bool;
+    public function isExcludeGitFiles(): bool;
 }

--- a/src/Helpers/FileSystem.php
+++ b/src/Helpers/FileSystem.php
@@ -109,8 +109,11 @@ class FileSystem implements FilesystemOperator, FlysystemBackCompatInterface, Pa
      * @return string[]
      * @throws FilesystemException
      */
-    public function findAllFilesAbsolutePaths(array $fileAndDirPaths, bool $excludeDirectories = false): array
-    {
+    public function findAllFilesAbsolutePaths(
+        array $fileAndDirPaths,
+        bool $excludeDirectories = false,
+        bool $deep = FilesystemReader::LIST_DEEP
+    ): array {
         $files = [];
 
         foreach ($fileAndDirPaths as $path) {
@@ -121,7 +124,7 @@ class FileSystem implements FilesystemOperator, FlysystemBackCompatInterface, Pa
 
             $directoryListing = $this->listContents(
                 $path,
-                FilesystemReader::LIST_DEEP
+                $deep
             );
 
             /** @var FileAttributes[] $fileAttributesArray */

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -68,7 +68,19 @@ class FileEnumerator
      */
     public function compileFileListForPaths(array $paths, ?ComposerPackage $dependency = null): DiscoveredFiles
     {
-        $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths($paths);
+        // First get the files in the root of the path.
+        $directoryListingByPath = [];
+        foreach ($paths as $path) {
+            $directoryListingByPath[$path] = $this->filesystem->findAllFilesAbsolutePaths([$path], false, false);
+        }
+
+        if ($this->config->isExcludeGitFiles()) {
+            foreach ($directoryListingByPath as $path => $files) {
+                $directoryListingByPath[$path] = $this->excludeGitFiles($paths, $files);
+            }
+        }
+
+        $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths(...array_values($directoryListingByPath));
 
         if ($this->config->isExcludeGitFiles()) {
             $absoluteFilePaths = $this->excludeGitFiles($paths, $absoluteFilePaths);

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -70,7 +70,7 @@ class FileEnumerator
     {
         $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths($paths);
 
-        if ($this->config->getExcludeGitFiles()) {
+        if ($this->config->isExcludeGitFiles()) {
             $absoluteFilePaths = $this->excludeGitFiles($paths, $absoluteFilePaths);
         }
 

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -70,15 +70,15 @@ class FileEnumerator
         array $paths,
         ?ComposerPackage $dependency = null
     ): DiscoveredFiles {
-        // First get the files in the root of the path.
+        // First, shallowly list each path's top-level entries (files and directories, non-recursive).
         $directoryListingByPath = [];
         foreach ($paths as $path) {
             $directoryListingByPath[$path] = $this->filesystem->findAllFilesAbsolutePaths([$path], false, false);
         }
 
         if ($this->config->isExcludeGitFiles()) {
-            // `$path` here is from the array of paths the method was called with, it is each `$files` entry we need,
-            // to check, to avoid wasting time getting directory listings for excluded directories.
+            // Apply the Git exclusion rules to each path's top-level entries before recursing, so we
+            // never deep-list (descend into) directories that Git would exclude, e.g. `.git`.
             foreach ($directoryListingByPath as $path => $files) {
                 $directoryListingByPath[$path] = $this->excludeGitFiles([$path], $files);
             }

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -80,7 +80,7 @@ class FileEnumerator
             // `$path` here is from the array of paths the method was called with, it is each `$files` entry we need,
             // to check, to avoid wasting time getting directory listings for excluded directories.
             foreach ($directoryListingByPath as $path => $files) {
-                $directoryListingByPath[$path] = $this->excludeGitFiles($paths, $files);
+                $directoryListingByPath[$path] = $this->excludeGitFiles([$path], $files);
             }
         }
 

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -120,6 +120,13 @@ class FileEnumerator
 
             $normalizedBasePath = rtrim(FileSystem::normalizeDirSeparator($basePath), '/');
 
+            // A `.git` directory is never part of the distributed package, so its presence alone is
+            // enough to enable pruning – even without a `.gitignore`/`.gitattributes`. Registering the
+            // base path here ensures `isGitExcluded()` runs its `.git` check for it.
+            if ($this->filesystem->directoryExists($normalizedBasePath . '/.git')) {
+                $repositories[$normalizedBasePath] ??= [];
+            }
+
             if ($this->filesystem->fileExists($normalizedBasePath . '/.gitignore')) {
                 try {
                     /**

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -136,7 +136,8 @@ class FileEnumerator
                     $repositories[$normalizedBasePath][ 'gitignore'] = $gitIgnoreChecker;
                 } catch (GitIgnoreCherkerException $e) {
                     // e.g. when the path is not on the local filesystem (in-memory tests).
-                    $this->logger->debug("Could not read .gitignore at {path}: {message}", [
+                    // The user explicitly enabled Git exclusion, so surface the failure to honour it.
+                    $this->logger->warning("Could not read .gitignore at {path}: {message}", [
                         'path' => $normalizedBasePath,
                         'message' => $e->getMessage(),
                     ]);
@@ -188,7 +189,7 @@ class FileEnumerator
                         return true;
                     }
                 } catch (GitIgnoreCherkerException $e) {
-                    $this->logger->debug("Could not check .gitignore for {path}: {message}", [
+                    $this->logger->warning("Could not check .gitignore for {path}: {message}", [
                         'path' => $sourceAbsolutePath,
                         'message' => $e->getMessage(),
                     ]);

--- a/src/Pipeline/FileEnumerator.php
+++ b/src/Pipeline/FileEnumerator.php
@@ -66,8 +66,10 @@ class FileEnumerator
      * @param string[] $paths
      * @throws FilesystemException
      */
-    public function compileFileListForPaths(array $paths, ?ComposerPackage $dependency = null): DiscoveredFiles
-    {
+    public function compileFileListForPaths(
+        array $paths,
+        ?ComposerPackage $dependency = null
+    ): DiscoveredFiles {
         // First get the files in the root of the path.
         $directoryListingByPath = [];
         foreach ($paths as $path) {
@@ -75,12 +77,14 @@ class FileEnumerator
         }
 
         if ($this->config->isExcludeGitFiles()) {
+            // `$path` here is from the array of paths the method was called with, it is each `$files` entry we need,
+            // to check, to avoid wasting time getting directory listings for excluded directories.
             foreach ($directoryListingByPath as $path => $files) {
                 $directoryListingByPath[$path] = $this->excludeGitFiles($paths, $files);
             }
         }
 
-        $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths(...array_values($directoryListingByPath));
+        $absoluteFilePaths = $this->filesystem->findAllFilesAbsolutePaths(array_merge(...array_values($directoryListingByPath)));
 
         if ($this->config->isExcludeGitFiles()) {
             $absoluteFilePaths = $this->excludeGitFiles($paths, $absoluteFilePaths);

--- a/tests/Integration/FileEnumeratorIntegrationTest.php
+++ b/tests/Integration/FileEnumeratorIntegrationTest.php
@@ -60,7 +60,7 @@ EOD;
 
         $config = $this->createStub(StraussConfig::class);
         $config->method('getAbsoluteVendorDirectory')->willReturn($vendorDir);
-        $config->method('getExcludeGitFiles')->willReturn(false);
+        $config->method('isExcludeGitFiles')->willReturn(false);
 
         $fileEnumerator = new FileEnumerator(
             $config,

--- a/tests/Integration/Pipeline/GitFilesFeatureTest.php
+++ b/tests/Integration/Pipeline/GitFilesFeatureTest.php
@@ -82,7 +82,7 @@ class GitFilesFeatureTest extends IntegrationTestCase
     private function createConfig(bool $excludeGitFiles): StraussConfig
     {
         $config = $this->createStub(StraussConfig::class);
-        $config->method('getExcludeGitFiles')->willReturn($excludeGitFiles);
+        $config->method('isExcludeGitFiles')->willReturn($excludeGitFiles);
         $config->method('getAbsoluteVendorDirectory')->willReturn($this->testsWorkingDir);
         $config->method('getAbsoluteTargetDirectory')->willReturn($this->testsWorkingDir . '/vendor-prefixed');
         return $config;

--- a/tests/Integration/Pipeline/GitFilesFeatureTest.php
+++ b/tests/Integration/Pipeline/GitFilesFeatureTest.php
@@ -132,4 +132,70 @@ class GitFilesFeatureTest extends IntegrationTestCase
         $this->assertDiscoveredContains($files, 'tests/RealTest.php');
         $this->assertDiscoveredContains($files, 'phpunit.xml');
     }
+
+    /**
+     * The performance optimisation prunes Git-excluded top-level entries (`.git`, the `.gitignore`d
+     * `build/`, the `export-ignore`d `tests/`) from a shallow listing *before* recursing, so those
+     * directories are never deep-listed.
+     *
+     * This is the whole reason `compileFileListForPaths()` uses a two-pass approach. Asserting only on
+     * the discovered file list (as the tests above do) would not catch a regression to the old
+     * single-pass code, because both approaches produce the same final list — the difference is only
+     * in which directories get walked.
+     */
+    public function test_excluded_directories_are_not_deep_listed(): void
+    {
+        $packageDir = $this->createTestPackage();
+
+        $spyFilesystem = $this->getListContentsSpyFileSystem();
+
+        $fileEnumerator = new FileEnumerator(
+            $this->createConfig(true),
+            $spyFilesystem,
+            $this->getLogger()
+        );
+
+        $fileEnumerator->compileFileListForPaths([$packageDir]);
+
+        $deepListedPaths = array_map(
+            fn(array $call): string => $call['location'],
+            array_filter($spyFilesystem->listContentsCalls, fn(array $call): bool => $call['deep'])
+        );
+
+        foreach ($deepListedPaths as $path) {
+            $this->assertDoesNotMatchRegularExpression('#/\.git(/|$)#', $path, '.git must not be deep-listed: ' . $path);
+            $this->assertDoesNotMatchRegularExpression('#/build(/|$)#', $path, 'Git-ignored build/ must not be deep-listed: ' . $path);
+            $this->assertDoesNotMatchRegularExpression('#/tests(/|$)#', $path, 'export-ignored tests/ must not be deep-listed: ' . $path);
+        }
+
+        // Sanity check: the kept `src/` directory *was* deep-listed, proving enumeration actually ran
+        // (so the assertions above are not vacuously true against an empty list).
+        $srcWasDeepListed = array_filter($deepListedPaths, fn(string $path): bool => (bool) preg_match('#/src$#', $path));
+        $this->assertNotEmpty(
+            $srcWasDeepListed,
+            'The kept src/ directory should have been deep-listed. Deep-listed: ' . implode(', ', $deepListedPaths)
+        );
+    }
+
+    /**
+     * A {@see FileSystem} which records every `listContents()` call so a test can assert which
+     * directories were walked, and whether the walk was deep (recursive) or shallow.
+     */
+    private function getListContentsSpyFileSystem(): ListContentsSpyFileSystem
+    {
+        $realFilesystem = $this->getFileSystem();
+
+        // Reuse the real filesystem's underlying Flysystem operator and working directory so the spy
+        // reads exactly the same files, differing only in that it records the listContents() calls.
+        $reflection = new \ReflectionObject($realFilesystem);
+        $flysystemProperty = $reflection->getProperty('flysystem');
+        $flysystemProperty->setAccessible(true);
+        $workingDirProperty = $reflection->getProperty('workingDir');
+        $workingDirProperty->setAccessible(true);
+
+        return new ListContentsSpyFileSystem(
+            $flysystemProperty->getValue($realFilesystem),
+            $workingDirProperty->getValue($realFilesystem)
+        );
+    }
 }

--- a/tests/Integration/Pipeline/GitFilesFeatureTest.php
+++ b/tests/Integration/Pipeline/GitFilesFeatureTest.php
@@ -134,6 +134,30 @@ class GitFilesFeatureTest extends IntegrationTestCase
     }
 
     /**
+     * The `.git` directory is never part of a distributed package, so it must be excluded whenever the
+     * flag is enabled – even for a package that has no `.gitignore`/`.gitattributes` to otherwise
+     * trigger Git processing.
+     */
+    public function test_git_directory_is_excluded_without_gitignore_or_gitattributes(): void
+    {
+        $packageDir = $this->testsWorkingDir . '/package-no-dotfiles';
+        $filesystem = $this->getFileSystem();
+        $filesystem->write($packageDir . '/src/Real.php', '<?php // keep');
+        $filesystem->write($packageDir . '/.git/config', '[core]');
+
+        $fileEnumerator = new FileEnumerator(
+            $this->createConfig(true),
+            $this->getFileSystem(),
+            $this->getLogger()
+        );
+
+        $files = $fileEnumerator->compileFileListForPaths([$packageDir]);
+
+        $this->assertDiscoveredContains($files, 'package-no-dotfiles/src/Real.php');
+        $this->assertDiscoveredNotContains($files, '.git/config');
+    }
+
+    /**
      * The performance optimisation prunes Git-excluded top-level entries (`.git`, the `.gitignore`d
      * `build/`, the `export-ignore`d `tests/`) from a shallow listing *before* recursing, so those
      * directories are never deep-listed.

--- a/tests/Integration/Pipeline/ListContentsSpyFileSystem.php
+++ b/tests/Integration/Pipeline/ListContentsSpyFileSystem.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BrianHenryIE\Strauss\Tests\Integration\Pipeline;
+
+use BrianHenryIE\Strauss\Helpers\FileSystem;
+use League\Flysystem\DirectoryListing;
+
+/**
+ * A {@see FileSystem} which records every `listContents()` call so a test can assert which directories
+ * were walked, and whether the walk was deep (recursive) or shallow.
+ *
+ * Used by {@see GitFilesFeatureTest::test_excluded_directories_are_not_deep_listed} to prove that
+ * Git-excluded directories are never recursed into.
+ */
+class ListContentsSpyFileSystem extends FileSystem
+{
+    /** @var array<int, array{location: string, deep: bool}> */
+    public array $listContentsCalls = [];
+
+    public function listContents(string $location, bool $deep = self::LIST_SHALLOW): DirectoryListing
+    {
+        $this->listContentsCalls[] = ['location' => $location, 'deep' => $deep];
+
+        return parent::listContents($location, $deep);
+    }
+}

--- a/tests/Unit/Composer/Extra/StraussConfigTest.php
+++ b/tests/Unit/Composer/Extra/StraussConfigTest.php
@@ -1103,7 +1103,7 @@ EOD;
             file_put_contents($tmpfname, $composerExtraStraussJson);
             $composer = Factory::create(new NullIO(), $tmpfname);
             $sut = new StraussConfig($composer);
-            $this->assertTrue($sut->getExcludeGitFiles());
+            $this->assertTrue($sut->isExcludeGitFiles());
         } finally {
             unlink($tmpfname);
         }
@@ -1126,7 +1126,7 @@ EOD;
             file_put_contents($tmpfname, $composerExtraStraussJson);
             $composer = Factory::create(new NullIO(), $tmpfname);
             $sut = new StraussConfig($composer);
-            $this->assertFalse($sut->getExcludeGitFiles());
+            $this->assertFalse($sut->isExcludeGitFiles());
         } finally {
             unlink($tmpfname);
         }

--- a/tests/Unit/FileEnumeratorTest.php
+++ b/tests/Unit/FileEnumeratorTest.php
@@ -28,7 +28,7 @@ class FileEnumeratorTest extends TestCase
     public function test_file_does_not_exist(): void
     {
         $config = Mockery::mock(FileEnumeratorConfig::class);
-        $config->allows('getExcludeGitFiles')->andReturnFalse();
+        $config->allows('isExcludeGitFiles')->andReturnFalse();
         $filesystem = $this->getInMemoryFileSystem();
         $logger = $this->getLogger();
 


### PR DESCRIPTION
When checking files in symlinked repos against `.gitignore` and `.gitattributes`, first check the top level files before then doing a deep directory listing on what remains.

The reasoning being the most consequential ignores will be at that level.

Worry: `.gitignore` in a subdirectory with a negation / inclusion will probably be missied